### PR TITLE
NameError (uninitialized constant ActiveInteractor::Organizer)

### DIFF
--- a/lib/active_interactor.rb
+++ b/lib/active_interactor.rb
@@ -34,6 +34,7 @@ module ActiveInteractor
   autoload :Configuration
   autoload :Context
   autoload :Interactor
+  autoload :Organizer
 
   class << self
     # The ActiveInteractor configuration

--- a/spec/active_interactor/organizer_spec.rb
+++ b/spec/active_interactor/organizer_spec.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe ActiveInteractor::Organizer do
+  subject { described_class }
+  it { should_not be_nil }
+end


### PR DESCRIPTION
## Description

<!-- Summarize the pull request -->
fixed #13 NameError (uninitialized constant ActiveInteractor::Organizer)

<!-- please include the relevant issue -->
<!-- replace "action" with one of the github keywords to relate the issue -->
fixes #13

## Information

- [ ] Contains Documentation
- [x] Contains Tests
- [ ] Contains Breaking Changes
