### PR TITLE
Alias context attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning].
 
 ## [Unreleased]
 
+### Added
+
 ## [v0.1.3] - 2019-04-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning].
 
 ### Added
 
+- [#28] The ability to alias attributes on interactor contexts.
+
 ## [v0.1.3] - 2019-04-01
 
 ### Added
@@ -48,3 +50,4 @@ and this project adheres to [Semantic Versioning].
 [#16]: https://github.com/aaronmallen/activeinteractor/pull/16
 [#22]: https://github.com/aaronmallen/activeinteractor/pull/22
 [#25]: https://github.com/aaronmallen/activeinteractor/pull/25
+[#28]: https://github.com/aaronmallen/activeinteractor/pull/28

--- a/README.md
+++ b/README.md
@@ -178,6 +178,38 @@ context.clean! #=> { occupation: 'Software Dude' }
 context.occupation #=> nil
 ```
 
+#### Aliasing Attributes
+
+Some times you may want to use the same interactor functionality with different
+model types having different naming conventions for similar attributes.  We can
+inform the interactors context of these aliases with the `context_attribute_aliases`
+method on our interactors.
+
+```ruby
+class MyInteractor < ActiveInteractor::Base
+  context_attributes :first_name, :last_name
+  context_attribute_aliases last_name: :sir_name
+end
+
+context = MyInteractor.perform(first_name: 'Aaron', sir_name: 'Allen')
+# => <#MyInteractor::Context first_name='Aaron', last_name='Allen'
+```
+
+We can also pass an array of aliases to the attribute like this:
+
+```ruby
+class MyInteractor < ActiveInteractor::Base
+  context_attributes :first_name, :last_name
+  context_attribute_aliases last_name: %i[sir_name sirname]
+end
+
+context = MyInteractor.perform(first_name: 'Aaron', sir_name: 'Allen')
+# => <#MyInteractor::Context first_name='Aaron', last_name='Allen'
+
+context = MyInteractor.perform(first_name: 'Aaron', sirname: 'Allen')
+# => <#MyInteractor::Context first_name='Aaron', last_name='Allen'
+```
+
 #### Validating the Context
 
 `ActiveInteractor` delegates all the validation methods provided by [ActiveModel::Validations]

--- a/lib/active_interactor/context/attributes.rb
+++ b/lib/active_interactor/context/attributes.rb
@@ -1,0 +1,194 @@
+# frozen_string_literal: true
+
+require 'active_support/core_ext/array/wrap'
+require 'active_support/core_ext/class/attribute'
+
+module ActiveInteractor
+  # ActiveInteractor::Context module
+  #
+  # @author Aaron Allen <hello@aaronmallen.me>
+  # @since 0.0.1
+  # @version 0.1
+  module Context
+    # Provides Context Attribute methods to included classes
+    #
+    # @author Aaron Allen <hello@aaronmallen.me>
+    # @since 0.1.4
+    # @version 0.1
+    module Attributes
+      extend ActiveSupport::Concern
+
+      included do
+        extend ClassMethods
+        class_attribute :__default_attributes, instance_writer: false, default: []
+      end
+
+      module ClassMethods
+        # Attributes defined on the context class
+        #
+        # @example Get attributes defined on a context class
+        #  MyInteractor::Context.attributes
+        #  #=> [:first_name, :last_name]
+        #
+        # @return [Array<Symbol>] the defined attributes
+        def attributes
+          __default_attributes
+            .concat(_validate_callbacks.map(&:filter).map(&:attributes).flatten)
+            .flatten
+            .uniq
+        end
+
+        # Set attributes on a context class
+        #
+        # @param attributes [Array<Symbol, String>] the attributes of the context
+        #
+        # @example Define attributes on a context class
+        #  MyInteractor::Context.attributes = :first_name, :last_name
+        #  #=> [:first_name, :last_name]
+        #
+        # @return [Array<Symbol>] the defined attributes
+        def attributes=(*attributes)
+          self.__default_attributes = self.attributes.concat(attributes.flatten.map(&:to_sym)).uniq
+        end
+
+        # Attribute aliases defined on the context class
+        #
+        # @example Get attribute aliases defined on a context class
+        #  MyInteractor::Context.attribute_aliases
+        #  #=> { last_name: [:sir_name] }
+        #
+        # @return [Hash{Symbol => Array<Symbol>}]
+        def attribute_aliases
+          @attribute_aliases ||= {}
+        end
+
+        # Set attribute aliases on the context class
+        #
+        # @param aliases [Hash{Symbol => Symbol, Array<Symbol>}] the attribute aliases of
+        #  the context
+        #
+        # @return [Hash{Symbol => Array<Symbol>}]
+        def alias_attributes(aliases = {})
+          map_attribute_aliases(aliases)
+          attribute_aliases
+        end
+
+        private
+
+        def map_attribute_aliases(aliases)
+          aliases.each_key do |attribute|
+            key = attribute.to_sym
+            attribute_aliases[key] ||= []
+            attribute_aliases[key].concat(Array.wrap(aliases[attribute]).map(&:to_sym))
+          end
+        end
+      end
+
+      def initialize(attributes = {})
+        super(map_attributes(attributes))
+      end
+
+      # Attributes defined on the instance
+      #
+      # @example Get attributes defined on an instance
+      #  MyInteractor::Context.attributes = :first_name, :last_name
+      #  #=> [:first_name, :last_name]
+      #
+      #  context = MyInteractor::Context.new(first_name: 'Aaron', last_name: 'Allen')
+      #  #=> <#MyInteractor::Context first_name='Aaron', last_name='Allen'>
+      #
+      #  context.attributes
+      #  #=> { first_name: 'Aaron', last_name: 'Allen' }
+      #
+      # @example Get attributes defined on an instance with unknown attribute
+      #  MyInteractor::Context.attributes = :first_name, :last_name
+      #  #=> [:first_name, :last_name]
+      #
+      #  context = MyInteractor::Context.new(first_name: 'Aaron', last_name: 'Allen', unknown: 'unknown')
+      #  #=> <#MyInteractor::Context first_name='Aaron', last_name='Allen', unknown='unknown'>
+      #
+      #  context.attributes
+      #  #=> { first_name: 'Aaron', last_name: 'Allen' }
+      #
+      #  context.unknown
+      #  #=> 'unknown'
+      #
+      # @return [Hash{Symbol => *}] the defined attributes and values
+      def attributes
+        self.class.attributes.each_with_object({}) do |attribute, hash|
+          hash[attribute] = self[attribute] if self[attribute]
+        end
+      end
+
+      # Removes properties from the instance that are not
+      # explicitly defined in the context instance {#attributes}
+      #
+      # @example Clean an instance of Context with unknown attribute
+      #  MyInteractor::Context.attributes = :first_name, :last_name
+      #  #=> [:first_name, :last_name]
+      #
+      #  context = MyInteractor::Context.new(first_name: 'Aaron', last_name: 'Allen', unknown: 'unknown')
+      #  #=> <#MyInteractor::Context first_name='Aaron', last_name='Allen', unknown='unknown'>
+      #
+      #  context.unknown
+      #  #=> 'unknown'
+      #
+      #  context.clean!
+      #  #=> { unknown: 'unknown' }
+      #
+      #  context.unknown
+      #  #=> nil
+      #
+      # @return [Hash{Symbol => *}] the deleted attributes
+      def clean!
+        deleted = {}
+        return deleted if keys.empty?
+
+        keys.reject { |key| self.class.attributes.include?(key) }.each do |attribute|
+          deleted[attribute] = self[attribute] if self[attribute]
+          delete_field(key.to_s)
+        end
+        deleted
+      end
+
+      # All keys of properties currently defined on the instance
+      #
+      # @example An instance of Context with unknown attribute
+      #  MyInteractor::Context.attributes = :first_name, :last_name
+      #  #=> [:first_name, :last_name]
+      #
+      #  context = MyInteractor::Context.new(first_name: 'Aaron', last_name: 'Allen', unknown: 'unknown')
+      #  #=> <#MyInteractor::Context first_name='Aaron', last_name='Allen', unknown='unknown'>
+      #
+      #  context.keys
+      #  #=> [:first_name, :last_name, :unknown]
+      #
+      # @return [Array<Symbol>] keys defined on the instance
+      def keys
+        each_pair.map { |pair| pair[0].to_sym }
+      end
+
+      private
+
+      def aliased_key(key)
+        self.class.attribute_aliases.each_pair do |attribute, aliases|
+          key = aliases.any? { |aliased| aliased == key.to_sym } ? attribute : key.to_sym
+        end
+        key
+      end
+
+      def map_attributes(attributes)
+        return {} unless attributes
+
+        attributes.keys.each_with_object({}) do |attribute, hash|
+          key = aliased_key(attribute)
+          hash[key] = attributes[attribute]
+        end
+      end
+
+      def new_ostruct_member!(name)
+        super(aliased_key(name))
+      end
+    end
+  end
+end

--- a/lib/active_interactor/context/errors.rb
+++ b/lib/active_interactor/context/errors.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module ActiveInteractor
+  module Context
+    # Raised when an interactor context fails
+    #
+    # @author Aaron Allen <hello@aaronmallen.me>
+    # @since 0.0.1
+    # @version 0.2
+    #
+    # @!attribute [r] context
+    #  @return [Base] an instance of {Base}
+    class Failure < StandardError
+      attr_reader :context
+
+      # A new instance of {Failure}
+      # @param context [ActiveInteractor::Context::Base] an
+      #  instance of {ActiveInteractor::Context::Base}
+      # @return [Failure] a new instance of {Failure}
+      def initialize(context = nil)
+        @context = context
+        super
+      end
+    end
+  end
+end

--- a/lib/active_interactor/interactor.rb
+++ b/lib/active_interactor/interactor.rb
@@ -81,7 +81,7 @@ module ActiveInteractor
       @should_clean_context.nil? && self.class.__clean_after_perform
     end
 
-    # Skip {ActiveInteractor::Context::Base#clean! #clean! on an interactor
+    # Skip {ActiveInteractor::Context::Attributes#clean! #clean! on an interactor
     #  context that calls the {Callbacks.clean_context_on_completion} class method.
     #  This method is meant to be invoked by organizer interactors
     #  to ensure contexts are approriately passed between interactors.

--- a/lib/active_interactor/interactor/context.rb
+++ b/lib/active_interactor/interactor/context.rb
@@ -7,7 +7,7 @@ module ActiveInteractor
     # @api private
     # @author Aaron Allen <hello@aaronmallen.me>
     # @since 0.0.1
-    # @version 0.1
+    # @version 0.2
     module Context
       extend ActiveSupport::Concern
 
@@ -40,6 +40,43 @@ module ActiveInteractor
         # @param attributes [Array] the attributes to assign to the context
         def context_attributes(*attributes)
           context_class.attributes = attributes
+        end
+
+        # Assign attribute aliases to the context class of the interactor
+        #  any aliases passed to the context will be assigned to the
+        #  key of the aliases hash
+        #
+        # @example Assign attribute aliases to the context class
+        #  class MyInteractor > ActiveInteractor::Base
+        #   context_attributes :first_name, :last_name
+        #   context_attribute_aliases last_name: :sir_name
+        #  end
+        #
+        #  MyInteractor::Context.attribute_aliases
+        #  #=> { last_name: [:sir_name] }
+        #
+        #  class MyInteractor > ActiveInteractor::Base
+        #   context_attributes :first_name, :last_name
+        #   context_attribute_aliases last_name: %i[sir_name, sirname]
+        #  end
+        #
+        #  MyInteractor::Context.attribute_aliases
+        #  #=> { last_name: [:sir_name, :sirname] }
+        #
+        #  context = MyInteractor.perform(first_name: 'Aaron', sir_name: 'Allen')
+        #  #=> <#MyInteractor::Context first_name='Aaron', last_name='Allen')
+        #
+        #  context.sir_name
+        #  #=> nil
+        #
+        #  context.last_name
+        #  #=> 'Allen'
+        #
+        # @param aliases [Hash{Symbol => Symbol, Array<Symbol>}] the attribute aliases
+        #
+        # @return [Hash{Symbol => Array<Symbol>}] the attribute aliases
+        def context_attribute_aliases(aliases = {})
+          context_class.alias_attributes(aliases)
         end
 
         # The context class of the interactor

--- a/spec/support/shared_exaples/context_lint.rb
+++ b/spec/support/shared_exaples/context_lint.rb
@@ -13,6 +13,8 @@ end
 RSpec.shared_examples 'An ActiveInteractor::Context::Base class respond_to' do
   it { should respond_to :attributes }
   it { should respond_to :attributes= }
+  it { should respond_to :attribute_aliases }
+  it { should respond_to :alias_attributes }
 
   ActiveModel::Validations::ClassMethods.instance_methods.each do |method|
     it { should respond_to method }
@@ -49,6 +51,29 @@ RSpec.shared_examples 'An ActiveInteractor::Context::Base class ClassMethods' do
     context 'with unique values `:foo`, `:foo` `:bar`, `:baz`' do
       before { subject.attributes = :foo, :foo, :bar, :baz }
       it { expect(subject.attributes).to eq %i[foo bar baz] }
+    end
+  end
+
+  describe '`#attribute_aliases`' do
+    context 'with no `attribute_aliases`' do
+      it { expect(subject.attribute_aliases).to be_a Hash }
+      it { expect(subject.attribute_aliases).to be_empty }
+    end
+
+    context 'with `attribute_aliases` `{foo: %i[bar]}`' do
+      before { subject.alias_attributes(foo: :bar) }
+      it { expect(subject.attribute_aliases).to be_a Hash }
+      it { expect(subject.attribute_aliases).to eq(foo: %i[bar]) }
+
+      context 'when creating an instance with bar: "test"' do
+        let(:instance) { subject.new('i', bar: 'test') }
+        it 'should not set `:bar`' do
+          expect(instance.bar).to be_nil
+        end
+        it 'should set `:foo` to "test"' do
+          expect(instance.foo).to eq 'test'
+        end
+      end
     end
   end
 end

--- a/spec/support/shared_exaples/interactor_lint.rb
+++ b/spec/support/shared_exaples/interactor_lint.rb
@@ -26,6 +26,7 @@ RSpec.shared_examples 'An ActiveInteractor::Base class respond_to' do
   it { should respond_to :before_rollback }
   it { should respond_to :clean_context_on_completion }
   it { should respond_to :context_attributes }
+  it { should respond_to :context_attribute_aliases }
   it { should respond_to :context_class }
   it { should respond_to :perform }
   it { should respond_to :perform! }
@@ -132,6 +133,27 @@ RSpec.shared_examples 'An ActiveInteractor::Base class ClassMethods' do
           .and_call_original
         subject.context_attributes :foo, :bar, :baz
         expect(subject.context_class.attributes).to eq %i[foo bar baz]
+      end
+    end
+  end
+
+  describe '`#context_attribute_aliases`' do
+    context 'with attribute aliases `foo: :bar`' do
+      it 'should assign the attribute aliases' do
+        expect(subject.context_class).to receive(:alias_attributes)
+          .with(foo: :bar)
+          .and_call_original
+        subject.context_attribute_aliases foo: :bar
+        expect(subject.context_class.attribute_aliases).to eq(foo: %i[bar])
+      end
+    end
+    context 'with attribute aliases `foo: [:bar, :baz]`' do
+      it 'should assign the attribute aliases' do
+        expect(subject.context_class).to receive(:alias_attributes)
+          .with(foo: %i[bar baz])
+          .and_call_original
+        subject.context_attribute_aliases foo: %i[bar baz]
+        expect(subject.context_class.attribute_aliases).to eq(foo: %i[bar baz])
       end
     end
   end


### PR DESCRIPTION
## Description

<!-- Summarize the pull request -->
Added the ability to alias context attributes

<!-- please include the relevant issue -->
<!-- replace "action" with one of the github keywords to relate the issue -->

## Information

- [x] Contains Documentation
- [x] Contains Tests
- [ ] Contains Breaking Changes

