### PR TITLE
fix small typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ context.occupation #=> nil
 
 #### Aliasing Attributes
 
-Some times you may want to use the same interactor functionality with different
+Sometimes you may want to use the same interactor functionality with different
 model types having different naming conventions for similar attributes.  We can
 inform the interactors context of these aliases with the `context_attribute_aliases`
 method on our interactors.
@@ -192,7 +192,7 @@ class MyInteractor < ActiveInteractor::Base
 end
 
 context = MyInteractor.perform(first_name: 'Aaron', sir_name: 'Allen')
-# => <#MyInteractor::Context first_name='Aaron', last_name='Allen'
+# => <#MyInteractor::Context first_name='Aaron', last_name='Allen'>
 ```
 
 We can also pass an array of aliases to the attribute like this:
@@ -204,10 +204,10 @@ class MyInteractor < ActiveInteractor::Base
 end
 
 context = MyInteractor.perform(first_name: 'Aaron', sir_name: 'Allen')
-# => <#MyInteractor::Context first_name='Aaron', last_name='Allen'
+# => <#MyInteractor::Context first_name='Aaron', last_name='Allen'>
 
 context = MyInteractor.perform(first_name: 'Aaron', sirname: 'Allen')
-# => <#MyInteractor::Context first_name='Aaron', last_name='Allen'
+# => <#MyInteractor::Context first_name='Aaron', last_name='Allen'>
 ```
 
 #### Validating the Context

--- a/lib/active_interactor/context/attributes.rb
+++ b/lib/active_interactor/context/attributes.rb
@@ -4,11 +4,6 @@ require 'active_support/core_ext/array/wrap'
 require 'active_support/core_ext/class/attribute'
 
 module ActiveInteractor
-  # ActiveInteractor::Context module
-  #
-  # @author Aaron Allen <hello@aaronmallen.me>
-  # @since 0.0.1
-  # @version 0.1
   module Context
     # Provides Context Attribute methods to included classes
     #


### PR DESCRIPTION
## Description

<!-- Summarize the pull request -->
Small typo in README

<!-- please include the relevant issue -->
<!-- replace "action" with one of the github keywords to relate the issue -->

## Information

- [x] Contains Documentation
- [ ] Contains Tests
- [ ] Contains Breaking Changes
