### PR TITLE
ActiveInteractor::Error

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    activeinteractor (0.1.4)
+    activeinteractor (0.1.5)
       activemodel (>= 4.2, < 6.1)
       activesupport (>= 4.2, < 6.1)
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ context.success? # => false
 
 #### Dealing with Failure
 
-`context.fail!` always throws an exception of type `ActiveInteractor::Context::Failure`.
+`context.fail!` always throws an exception of type `ActiveInteractor::Error::ContextFailure`.
 
 Normally, however, these exceptions are not seen. In the recommended usage, the consuming
 object invokes the interactor using the class method call, then checks the `success?` method of

--- a/lib/active_interactor.rb
+++ b/lib/active_interactor.rb
@@ -36,6 +36,10 @@ module ActiveInteractor
   autoload :Interactor
   autoload :Organizer
 
+  eager_autoload do
+    autoload :Error
+  end
+
   class << self
     # The ActiveInteractor configuration
     # @return [ActiveInteractor::Configuration] the configuration instance

--- a/lib/active_interactor/context.rb
+++ b/lib/active_interactor/context.rb
@@ -49,15 +49,15 @@ module ActiveInteractor
       #  #=> <#MyInteractor name='Aaron'>
       #
       #  interactor.context.fail!
-      #  #=> ActiveInteractor::Context::Failure: <#MyInteractor::Context name='Aaron'>
+      #  #=> ActiveInteractor::Error::ContextFailure: <#MyInteractor::Context name='Aaron'>
       #
       # @param errors [ActiveModel::Errors, Hash] errors to add to the context on failure
       # @see https://api.rubyonrails.org/classes/ActiveModel/Errors.html ActiveModel::Errors
-      # @raise [Failure]
+      # @raise [Error::ContextFailure]
       def fail!(errors = {})
         self.errors.merge!(errors) unless errors.empty?
         @_failed = true
-        raise Failure, self
+        raise Error::ContextFailure, self
       end
 
       # Whether the context instance has failed. By default, a new
@@ -73,7 +73,7 @@ module ActiveInteractor
       #  false
       #
       #  context.fail!
-      #  #=> ActiveInteractor::Context::Failure: <#MyInteractor::Context>
+      #  #=> ActiveInteractor::Error::ContextFailure: <#MyInteractor::Context>
       #
       #  context.failure?
       #  #=> true
@@ -138,7 +138,7 @@ module ActiveInteractor
       #  true
       #
       #  context.fail!
-      #  #=> ActiveInteractor::Context::Failure: <#MyInteractor::Context>
+      #  #=> ActiveInteractor::Error::ContextFailure: <#MyInteractor::Context>
       #
       #  context.success?
       #  #=> false

--- a/lib/active_interactor/error.rb
+++ b/lib/active_interactor/error.rb
@@ -1,24 +1,27 @@
 # frozen_string_literal: true
 
 module ActiveInteractor
-  module Context
+  # ActiveInteractor::Error module
+  #
+  # @author Aaron Allen <hello@aaronmallen.me>
+  # @since 0.1.5
+  # @version 0.1
+  module Error
     # Raised when an interactor context fails
     #
-    # @deprecated Use {#ActiveInteractor::Error::ContextFailure} instead
-    #
     # @author Aaron Allen <hello@aaronmallen.me>
-    # @since 0.0.1
-    # @version 0.2
+    # @since 0.1.5
+    # @version 0.1
     #
     # @!attribute [r] context
     #  @return [Base] an instance of {Base}
-    class Failure < StandardError
+    class ContextFailure < StandardError
       attr_reader :context
 
-      # A new instance of {Failure}
+      # A new instance of {ContextFailure}
       # @param context [ActiveInteractor::Context::Base] an
       #  instance of {ActiveInteractor::Context::Base}
-      # @return [Failure] a new instance of {Failure}
+      # @return [ContextFailure] a new instance of {ContextFailure}
       def initialize(context = nil)
         @context = context
         super

--- a/lib/active_interactor/interactor.rb
+++ b/lib/active_interactor/interactor.rb
@@ -36,7 +36,7 @@ module ActiveInteractor
 
       # Invoke an Interactor. The {.perform!} method behaves identically to
       #  the {.perform} method with one notable exception. If the context is failed
-      #  during invocation of the interactor, the {ActiveInteractor::Context::Failure}
+      #  during invocation of the interactor, the {ActiveInteractor::Error::ContextFailure}
       #  is raised.
       #
       # @example Run an interactor

--- a/lib/active_interactor/interactor/worker.rb
+++ b/lib/active_interactor/interactor/worker.rb
@@ -18,17 +18,17 @@ module ActiveInteractor
         @interactor = clone_interactor(interactor)
       end
 
-      # Calls {#execute_perform!} and rescues {ActiveInteractor::Context::Failure}
+      # Calls {#execute_perform!} and rescues {ActiveInteractor::Error::ContextFailure}
       # @return [ActiveInteractor::Context::Base] an instance of {ActiveInteractor::Context::Base}
       def execute_perform
         execute_perform!
-      rescue ActiveInteractor::Context::Failure => e
+      rescue ActiveInteractor::Error::ContextFailure => e
         ActiveInteractor.logger.error("ActiveInteractor: #{e}")
         context
       end
 
       # Calls {Interactor#perform} with callbacks and context validation
-      # @raise [ActiveInteractor::Context::Failure] if the context fails
+      # @raise [ActiveInteractor::Error::ContextFailure] if the context fails
       # @return [ActiveInteractor::Context::Base] an instance of {ActiveInteractor::Context::Base}
       def execute_perform!
         run_callbacks :perform do

--- a/lib/active_interactor/version.rb
+++ b/lib/active_interactor/version.rb
@@ -3,5 +3,5 @@
 module ActiveInteractor
   # The ActiveInteractor gem version
   # @return [String] the gem version
-  VERSION = '0.1.4'
+  VERSION = '0.1.5'
 end

--- a/spec/active_interactor/interactor/worker_spec.rb
+++ b/spec/active_interactor/interactor/worker_spec.rb
@@ -17,9 +17,9 @@ RSpec.describe ActiveInteractor::Interactor::Worker do
         subject
       end
 
-      context 'when `#execute_perform!` raises `ActiveInteractor::Context::Failure`' do
+      context 'when `#execute_perform!` raises `ActiveInteractor::Error::ContextFailure`' do
         before do
-          error = ActiveInteractor::Context::Failure.new
+          error = ActiveInteractor::Error::ContextFailure.new
           allow(ActiveInteractor.logger).to receive(:error).and_return(true)
           expect(worker).to receive(:execute_perform!).and_raise(error)
         end

--- a/spec/active_interactor/organizer_spec.rb
+++ b/spec/active_interactor/organizer_spec.rb
@@ -47,9 +47,9 @@ RSpec.describe ActiveInteractor::Organizer do
           subject
         end
 
-        context 'when `TestInteractor1 `raises `ActiveInteractor::Context::Failure`' do
+        context 'when `TestInteractor1 `raises `ActiveInteractor::Error::ContextFailure`' do
           before do
-            error = ActiveInteractor::Context::Failure.new
+            error = ActiveInteractor::Error::ContextFailure.new
             allow(ActiveInteractor.logger).to receive(:error).and_return(true)
             allow_any_instance_of(TestInteractor1).to receive(:execute_perform!)
               .and_raise(error)


### PR DESCRIPTION
## Description

<!-- Summarize the pull request -->
* Created the `ActiveInteractor::Error` module
* Deprecated `ActiveInteractor::Context::Failure` in favor of `ActiveInteractor::Error::ContextFailure`

<!-- please include the relevant issue -->
<!-- replace "action" with one of the github keywords to relate the issue -->

## Information

- [x] Contains Documentation
- [x] Contains Tests
- [ ] Contains Breaking Changes
