### PR TITLE
v0.1.6 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning].
 
 ## [Unreleased]
 
+## [v0.1.6] - 2019-07-24
+
+### Changed
+
+- [#45] Lowered method complexity and enforced single responsibility
+
+### Security
+
+- [#48] Update simplecov: 0.16.1 → 0.17.0 (major)
+- [#51] Update rake: 12.3.2 → 12.3.3 (patch)
+
 ## [v0.1.5] - 2019-06-30
 
 ### Added
@@ -57,7 +68,8 @@ and this project adheres to [Semantic Versioning].
 
 <!-- versions -->
 
-[Unreleased]: https://github.com/aaronmallen/activeinteractor/compare/v0.1.5..HEAD
+[Unreleased]: https://github.com/aaronmallen/activeinteractor/compare/v0.1.6..HEAD
+[v0.1.6]: https://github.com/aaronmallen/activeinteractor/compare/v0.1.5...v0.1.6
 [v0.1.5]: https://github.com/aaronmallen/activeinteractor/compare/v0.1.4...v0.1.5
 [v0.1.4]: https://github.com/aaronmallen/activeinteractor/compare/v0.1.3...v0.1.4
 [v0.1.3]: https://github.com/aaronmallen/activeinteractor/compare/v0.1.2...v0.1.3
@@ -76,3 +88,6 @@ and this project adheres to [Semantic Versioning].
 [#37]: https://github.com/aaronmallen/activeinteractor/pull/37
 [#38]: https://github.com/aaronmallen/activeinteractor/pull/38
 [#39]: https://github.com/aaronmallen/activeinteractor/pull/39
+[#45]: https://github.com/aaronmallen/activeinteractor/pull/45
+[#48]: https://github.com/aaronmallen/activeinteractor/pull/48
+[#51]: https://github.com/aaronmallen/activeinteractor/pull/51

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    activeinteractor (0.1.5)
+    activeinteractor (0.1.6)
       activemodel (>= 4.2, < 6.1)
       activesupport (>= 4.2, < 6.1)
 

--- a/lib/active_interactor/version.rb
+++ b/lib/active_interactor/version.rb
@@ -3,5 +3,5 @@
 module ActiveInteractor
   # The ActiveInteractor gem version
   # @return [String] the gem version
-  VERSION = '0.1.5'
+  VERSION = '0.1.6'
 end


### PR DESCRIPTION
With this release we will be placing version 0.1 of the gem into maintenance mode. All new features will go into v1.0.0 of the gem and only bug fixes will be done on 0.1
  
### Changed

- [#45] Lowered method complexity and enforced single responsibility

### Security

- [#48] Update simplecov: 0.16.1 → 0.17.0 (major)
- [#51] Update rake: 12.3.2 → 12.3.3 (patch)