### PR TITLE
v0.1.6 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning].
 
 ## [Unreleased]
 
+## [v0.1.6] - 2019-07-24
+
+### Changed
+
+- [#45] Lowered method complexity and enforced single responsibility
+
+### Security
+
+- [#48] Update simplecov: 0.16.1 → 0.17.0 (major)
+- [#51] Update rake: 12.3.2 → 12.3.3 (patch)
+
 ## [v0.1.5] - 2019-06-30
 
 ### Added
@@ -57,7 +68,8 @@ and this project adheres to [Semantic Versioning].
 
 <!-- versions -->
 
-[Unreleased]: https://github.com/aaronmallen/activeinteractor/compare/v0.1.5..HEAD
+[Unreleased]: https://github.com/aaronmallen/activeinteractor/compare/v0.1.6..HEAD
+[v0.1.6]: https://github.com/aaronmallen/activeinteractor/compare/v0.1.5...v0.1.6
 [v0.1.5]: https://github.com/aaronmallen/activeinteractor/compare/v0.1.4...v0.1.5
 [v0.1.4]: https://github.com/aaronmallen/activeinteractor/compare/v0.1.3...v0.1.4
 [v0.1.3]: https://github.com/aaronmallen/activeinteractor/compare/v0.1.2...v0.1.3
@@ -76,3 +88,6 @@ and this project adheres to [Semantic Versioning].
 [#37]: https://github.com/aaronmallen/activeinteractor/pull/37
 [#38]: https://github.com/aaronmallen/activeinteractor/pull/38
 [#39]: https://github.com/aaronmallen/activeinteractor/pull/39
+[#45]: https://github.com/aaronmallen/activeinteractor/pull/45
+[#48]: https://github.com/aaronmallen/activeinteractor/pull/48
+[#51]: https://github.com/aaronmallen/activeinteractor/pull/51

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -54,7 +54,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
     rspec-support (3.8.2)
-    rubocop (0.72.0)
+    rubocop (0.73.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
       parser (>= 2.6)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,7 +62,7 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.7)
     ruby-progressbar (1.10.1)
-    simplecov (0.16.1)
+    simplecov (0.17.0)
       docile (~> 1.1)
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,7 +37,7 @@ GEM
     parser (2.6.3.0)
       ast (~> 2.4.0)
     rainbow (3.0.0)
-    rake (12.3.2)
+    rake (12.3.3)
     redcarpet (3.4.0)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    activeinteractor (0.1.5)
+    activeinteractor (0.1.6)
       activemodel (>= 4.2, < 6.1)
       activesupport (>= 4.2, < 6.1)
 

--- a/lib/active_interactor/context.rb
+++ b/lib/active_interactor/context.rb
@@ -55,9 +55,9 @@ module ActiveInteractor
       # @see https://api.rubyonrails.org/classes/ActiveModel/Errors.html ActiveModel::Errors
       # @raise [Error::ContextFailure]
       def fail!(errors = {})
-        self.errors.merge!(errors) unless errors.empty?
-        @_failed = true
-        raise Error::ContextFailure, self
+        merge_errors(errors)
+        mark_failed!
+        raise_context_failure!
       end
 
       # Whether the context instance has failed. By default, a new
@@ -121,8 +121,8 @@ module ActiveInteractor
       def rollback!
         return false if @_rolled_back
 
-        _called.reverse_each(&:execute_rollback)
-        @_rolled_back = true
+        rollback_called
+        mark_rolledback!
       end
 
       # Whether the context instance is successful. By default, a new
@@ -160,6 +160,26 @@ module ActiveInteractor
 
       def _called
         @_called ||= []
+      end
+
+      def mark_failed!
+        @_failed = true
+      end
+
+      def mark_rolledback!
+        @_rolled_back = true
+      end
+
+      def merge_errors(errors)
+        self.errors.merge!(errors) unless errors.empty?
+      end
+
+      def raise_context_failure!
+        raise Error::ContextFailure, self
+      end
+
+      def rollback_called
+        _called.reverse_each(&:execute_rollback)
       end
 
       def validation_callback?(method_name)

--- a/lib/active_interactor/context/attributes.rb
+++ b/lib/active_interactor/context/attributes.rb
@@ -136,14 +136,9 @@ module ActiveInteractor
       #
       # @return [Hash{Symbol => *}] the deleted attributes
       def clean!
-        deleted = {}
-        return deleted if keys.empty?
+        return {} if keys.empty?
 
-        keys.reject { |key| self.class.attributes.include?(key) }.each do |attribute|
-          deleted[attribute] = self[attribute] if self[attribute]
-          delete_field(key.to_s)
-        end
-        deleted
+        clean_keys!
       end
 
       # All keys of properties currently defined on the instance
@@ -170,6 +165,13 @@ module ActiveInteractor
           key = aliases.any? { |aliased| aliased == key.to_sym } ? attribute : key.to_sym
         end
         key
+      end
+
+      def clean_keys!
+        keys.reject { |key| self.class.attributes.include?(key) }.each_with_object({}) do |attribute, deleted|
+          deleted[attribute] = self[attribute] if self[attribute]
+          delete_field(key.to_s)
+        end
       end
 
       def map_attributes(attributes)

--- a/lib/active_interactor/organizer.rb
+++ b/lib/active_interactor/organizer.rb
@@ -170,11 +170,21 @@ module ActiveInteractor
     #  in favor of this default implementation.
     def perform
       self.class.organized.each do |interactor|
-        run_callbacks :each_perform do
-          self.context = interactor.new(context)
-                                   .tap(&:skip_clean_context!)
-                                   .execute_perform!
-        end
+        execute_interactor_perform_with_callbacks!(interactor)
+      end
+    end
+
+    private
+
+    def execute_interactor_perform!(interactor)
+      self.context = interactor.new(context)
+                               .tap(&:skip_clean_context!)
+                               .execute_perform!
+    end
+
+    def execute_interactor_perform_with_callbacks!(interactor)
+      run_callbacks :each_perform do
+        execute_interactor_perform!(interactor)
       end
     end
   end

--- a/lib/active_interactor/version.rb
+++ b/lib/active_interactor/version.rb
@@ -3,5 +3,5 @@
 module ActiveInteractor
   # The ActiveInteractor gem version
   # @return [String] the gem version
-  VERSION = '0.1.5'
+  VERSION = '0.1.6'
 end


### PR DESCRIPTION
With this release we will be placing version 0.1 of the gem into maintenance mode. All new features will go into v1.0.0 of the gem and only bug fixes will be done on 0.1
  
### Changed

- [#45] Lowered method complexity and enforced single responsibility

### Security

- [#48] Update simplecov: 0.16.1 → 0.17.0 (major)
- [#51] Update rake: 12.3.2 → 12.3.3 (patch)