### PR TITLE
#95 added configuration option for context generators

### DIFF
--- a/lib/active_interactor/rails/config.rb
+++ b/lib/active_interactor/rails/config.rb
@@ -7,16 +7,22 @@ module ActiveInteractor
     # @since 1.0.0
     # @!attribute [rw] directory
     #  @return [String] the directory interactors are stored in
+    # @!attribute [rw] generate_context_classes
+    #  @return [Boolean] whether or not to generate a seperate
+    #    context class for an interactor.
     class Config
       # @return [Hash{Symbol=>*}] the default configuration options
       DEFAULTS = {
-        directory: 'interactors'
+        directory: 'interactors',
+        generate_context_classes: true
       }.freeze
 
-      attr_accessor :directory
+      attr_accessor :directory, :generate_context_classes
 
       # @param options [Hash] the options for the configuration
-      # @option options [String] :directory the configuration directory property
+      # @option options [String] :directory (defaults to: 'interactors') the configuration directory property
+      # @option options [Boolean] :generate_context_classes (defaults to: `true`) the configuration
+      #   generate_context_class property.
       # @return [Config] a new instance of {Config}
       def initialize(options = {})
         DEFAULTS.dup.merge(options).each do |key, value|

--- a/lib/rails/generators/active_interactor/application_interactor_generator.rb
+++ b/lib/rails/generators/active_interactor/application_interactor_generator.rb
@@ -16,6 +16,8 @@ module ActiveInteractor
       end
 
       def create_application_context
+        return if ActiveInteractor.config.rails.generate_context_classes == false
+
         template 'application_context.rb', File.join(target_path, 'application_context.rb')
       end
 

--- a/lib/rails/generators/active_interactor/templates/initializer.erb
+++ b/lib/rails/generators/active_interactor/templates/initializer.erb
@@ -12,4 +12,8 @@ ActiveInteractor.configure do |config|
   <%- else -%>
   # config.rails.directory = 'interactors'
   <%- end -%>
+
+  # do not automatically generate context classes
+  # when interactors are generated
+  # config.rails.generate_context_classes = false
 end

--- a/lib/rails/generators/interactor/interactor_generator.rb
+++ b/lib/rails/generators/interactor/interactor_generator.rb
@@ -11,6 +11,8 @@ class InteractorGenerator < ActiveInteractor::Generators::NamedBase
   end
 
   def create_context
+    return if ActiveInteractor.config.rails.generate_context_classes == false
+
     generate :'interactor:context', class_name
   end
 

--- a/lib/rails/generators/interactor/organizer_generator.rb
+++ b/lib/rails/generators/interactor/organizer_generator.rb
@@ -14,6 +14,8 @@ module Interactor
       end
 
       def create_context
+        return if ActiveInteractor.config.rails.generate_context_classes == false
+
         generate :'interactor:context', class_name
       end
 

--- a/spec/active_interactor/rails/config_spec.rb
+++ b/spec/active_interactor/rails/config_spec.rb
@@ -7,4 +7,5 @@ RSpec.describe ActiveInteractor::Rails::Config do
   subject { described_class.new }
 
   it { is_expected.to respond_to :directory }
+  it { is_expected.to respond_to :generate_context_classes }
 end


### PR DESCRIPTION
## Description

<!-- Summarize the pull request -->
added configuration option for context generators

## Information

- [x] Contains Documentation
- [x] Contains Tests
- [ ] Contains Breaking Changes

## Related Issues

<!-- besure to use the github action format for issues -->
<!-- <action> [issue_id] -->
<!-- i.e. "resloves #1" -->
<!-- delete this if there are no related issues -->
- resolves #95

## Changelog

<!-- provide any changelog items this pull request implements -->
<!-- follow the keep a changelog format -->
<!-- see https://keepachangelog.com/en/1.0.0/ -->
<!-- delete any unused headings -->

### Added

- `ActiveInteractor::Rails::Config#generate_context_classes`

### Changed

- Interactor generators will no longer generate separate context classes for interactors if `ActiveInteractor.config.rails.generate_context_classes` is set to `false` 