### PR TITLE
#97 add context_attributes argument to context generators

### DIFF
--- a/lib/rails/generators/active_interactor.rb
+++ b/lib/rails/generators/active_interactor.rb
@@ -17,14 +17,14 @@ module ActiveInteractor
       def self.included(base)
         base.class_eval do
           argument :context_attributes, type: :array, default: [], banner: 'attribute attribute'
-          class_option :context, type: :boolean
+          class_option :skip_context, type: :boolean
         end
       end
 
       private
 
       def skip_context?
-        options[:context] == false || ActiveInteractor.config.rails.generate_context_classes == false
+        options[:skip_context] == true || ActiveInteractor.config.rails.generate_context_classes == false
       end
     end
 

--- a/lib/rails/generators/active_interactor.rb
+++ b/lib/rails/generators/active_interactor.rb
@@ -17,7 +17,7 @@ module ActiveInteractor
       def self.included(base)
         base.class_eval do
           argument :context_attributes, type: :array, default: [], banner: 'attribute attribute'
-          class_option :skip_context, type: :boolean, desc: "Whether or not to generate a context class"
+          class_option :skip_context, type: :boolean, desc: 'Whether or not to generate a context class'
         end
       end
 

--- a/lib/rails/generators/active_interactor.rb
+++ b/lib/rails/generators/active_interactor.rb
@@ -17,7 +17,7 @@ module ActiveInteractor
       def self.included(base)
         base.class_eval do
           argument :context_attributes, type: :array, default: [], banner: 'attribute attribute'
-          class_option :skip_context, type: :boolean
+          class_option :skip_context, type: :boolean, desc: "Whether or not to generate a context class"
         end
       end
 

--- a/lib/rails/generators/active_interactor.rb
+++ b/lib/rails/generators/active_interactor.rb
@@ -8,10 +8,26 @@ module ActiveInteractor
     module Generator
       private
 
-      def interactor_dir
-        @interactor_dir ||= ActiveInteractor.config.rails.directory
+      def interactor_directory
+        @interactor_directory ||= ActiveInteractor.config.rails.directory
       end
     end
+
+    module GeneratesContext
+      def self.included(base)
+        base.class_eval do
+          argument :context_attributes, type: :array, default: [], banner: 'attribute attribute'
+          class_option :context, type: :boolean
+        end
+      end
+
+      private
+
+      def skip_context?
+        options[:context] == false || ActiveInteractor.config.rails.generate_context_classes == false
+      end
+    end
+
     class Base < ::Rails::Generators::Base
       include Generator
     end

--- a/lib/rails/generators/active_interactor/application_interactor_generator.rb
+++ b/lib/rails/generators/active_interactor/application_interactor_generator.rb
@@ -24,7 +24,7 @@ module ActiveInteractor
       private
 
       def target_path
-        "app/#{interactor_dir}"
+        "app/#{interactor_directory}"
       end
     end
   end

--- a/lib/rails/generators/active_interactor/templates/initializer.erb
+++ b/lib/rails/generators/active_interactor/templates/initializer.erb
@@ -7,11 +7,11 @@ ActiveInteractor.configure do |config|
   config.logger = ::Rails.logger
 
   # set the default directory for interactors
-  <%- if directory != 'interactors' -%>
+<%- if directory != 'interactors' -%>
   config.rails.directory = '<%= directory %>'
-  <%- else -%>
+<%- else -%>
   # config.rails.directory = 'interactors'
-  <%- end -%>
+<%- end -%>
 
   # do not automatically generate context classes
   # when interactors are generated

--- a/lib/rails/generators/interactor/context/rspec_generator.rb
+++ b/lib/rails/generators/interactor/context/rspec_generator.rb
@@ -16,7 +16,7 @@ module Interactor
         private
 
         def file_path
-          File.join('spec', interactor_dir, File.join(class_path), "#{file_name}_context_spec.rb")
+          File.join('spec', interactor_directory, File.join(class_path), "#{file_name}_context_spec.rb")
         end
       end
     end

--- a/lib/rails/generators/interactor/context/test_unit_generator.rb
+++ b/lib/rails/generators/interactor/context/test_unit_generator.rb
@@ -16,7 +16,7 @@ module Interactor
         private
 
         def file_path
-          File.join('test', interactor_dir, File.join(class_path), "#{file_name}_context_test.rb")
+          File.join('test', interactor_directory, File.join(class_path), "#{file_name}_context_test.rb")
         end
       end
     end

--- a/lib/rails/generators/interactor/context_generator.rb
+++ b/lib/rails/generators/interactor/context_generator.rb
@@ -5,9 +5,9 @@ require_relative '../active_interactor'
 module Interactor
   module Generators
     class ContextGenerator < ActiveInteractor::Generators::NamedBase
+      include ActiveInteractor::Generators::GeneratesContext
       source_root File.expand_path('templates', __dir__)
       desc 'Generate an interactor context'
-      argument :interactors, type: :array, default: [], banner: 'name name'
 
       def create_context
         template 'context.erb', file_path
@@ -18,7 +18,7 @@ module Interactor
       private
 
       def file_path
-        File.join('app', interactor_dir, File.join(class_path), "#{file_name}_context.rb")
+        File.join('app', interactor_directory, File.join(class_path), "#{file_name}_context.rb")
       end
     end
   end

--- a/lib/rails/generators/interactor/interactor_generator.rb
+++ b/lib/rails/generators/interactor/interactor_generator.rb
@@ -3,6 +3,7 @@
 require_relative '../active_interactor'
 
 class InteractorGenerator < ActiveInteractor::Generators::NamedBase
+  include ActiveInteractor::Generators::GeneratesContext
   source_root File.expand_path('templates', __dir__)
   desc 'Generate an interactor'
 
@@ -11,9 +12,9 @@ class InteractorGenerator < ActiveInteractor::Generators::NamedBase
   end
 
   def create_context
-    return if ActiveInteractor.config.rails.generate_context_classes == false
+    return if skip_context?
 
-    generate :'interactor:context', class_name
+    generate :'interactor:context', class_name, *context_attributes
   end
 
   hook_for :test_framework, in: :interactor
@@ -21,6 +22,6 @@ class InteractorGenerator < ActiveInteractor::Generators::NamedBase
   private
 
   def file_path
-    File.join('app', interactor_dir, File.join(class_path), "#{file_name}.rb")
+    File.join('app', interactor_directory, File.join(class_path), "#{file_name}.rb")
   end
 end

--- a/lib/rails/generators/interactor/organizer_generator.rb
+++ b/lib/rails/generators/interactor/organizer_generator.rb
@@ -10,7 +10,7 @@ module Interactor
       argument :interactors, type: :array, default: [], banner: 'interactor interactor'
 
       class_option :context_attributes, type: :array, default: [], banner: 'attribute attribute'
-      class_option :context, type: :boolean
+      class_option :skip_context, type: :boolean
 
       def create_organizer
         template 'organizer.erb', file_path
@@ -35,7 +35,7 @@ module Interactor
       end
 
       def skip_context?
-        options[:context] == false || ActiveInteractor.config.rails.generate_context_classes == false
+        options[:skip_context] == true || ActiveInteractor.config.rails.generate_context_classes == false
       end
     end
   end

--- a/lib/rails/generators/interactor/organizer_generator.rb
+++ b/lib/rails/generators/interactor/organizer_generator.rb
@@ -9,8 +9,8 @@ module Interactor
       desc 'Generate an interactor organizer'
       argument :interactors, type: :array, default: [], banner: 'interactor interactor'
 
-      class_option :context_attributes, type: :array, default: [], banner: 'attribute attribute'
-      class_option :skip_context, type: :boolean
+      class_option :context_attributes, type: :array, default: [], banner: 'attribute attribute', desc: "Attributes for the context"
+      class_option :skip_context, type: :boolean, desc: "Whether or not to generate a context class"
 
       def create_organizer
         template 'organizer.erb', file_path

--- a/lib/rails/generators/interactor/organizer_generator.rb
+++ b/lib/rails/generators/interactor/organizer_generator.rb
@@ -5,10 +5,12 @@ require_relative '../active_interactor'
 module Interactor
   module Generators
     class OrganizerGenerator < ActiveInteractor::Generators::NamedBase
-      include ActiveInteractor::Generators::GeneratesContext
       source_root File.expand_path('templates', __dir__)
       desc 'Generate an interactor organizer'
-      argument :interactors, type: :array, default: [], banner: 'name name'
+      argument :interactors, type: :array, default: [], banner: 'interactor interactor'
+
+      class_option :context_attributes, type: :array, default: [], banner: 'attribute attribute'
+      class_option :context, type: :boolean
 
       def create_organizer
         template 'organizer.erb', file_path
@@ -24,8 +26,16 @@ module Interactor
 
       private
 
+      def context_attributes
+        options[:context_attributes]
+      end
+
       def file_path
         File.join('app', interactor_directory, File.join(class_path), "#{file_name}.rb")
+      end
+
+      def skip_context?
+        options[:context] == false || ActiveInteractor.config.rails.generate_context_classes == false
       end
     end
   end

--- a/lib/rails/generators/interactor/organizer_generator.rb
+++ b/lib/rails/generators/interactor/organizer_generator.rb
@@ -5,6 +5,7 @@ require_relative '../active_interactor'
 module Interactor
   module Generators
     class OrganizerGenerator < ActiveInteractor::Generators::NamedBase
+      include ActiveInteractor::Generators::GeneratesContext
       source_root File.expand_path('templates', __dir__)
       desc 'Generate an interactor organizer'
       argument :interactors, type: :array, default: [], banner: 'name name'
@@ -14,9 +15,9 @@ module Interactor
       end
 
       def create_context
-        return if ActiveInteractor.config.rails.generate_context_classes == false
+        return if skip_context?
 
-        generate :'interactor:context', class_name
+        generate :'interactor:context', class_name, *context_attributes
       end
 
       hook_for :test_framework, in: :interactor
@@ -24,7 +25,7 @@ module Interactor
       private
 
       def file_path
-        File.join('app', interactor_dir, File.join(class_path), "#{file_name}.rb")
+        File.join('app', interactor_directory, File.join(class_path), "#{file_name}.rb")
       end
     end
   end

--- a/lib/rails/generators/interactor/organizer_generator.rb
+++ b/lib/rails/generators/interactor/organizer_generator.rb
@@ -9,8 +9,9 @@ module Interactor
       desc 'Generate an interactor organizer'
       argument :interactors, type: :array, default: [], banner: 'interactor interactor'
 
-      class_option :context_attributes, type: :array, default: [], banner: 'attribute attribute', desc: "Attributes for the context"
-      class_option :skip_context, type: :boolean, desc: "Whether or not to generate a context class"
+      class_option :context_attributes, type: :array, default: [], banner: 'attribute attribute',
+                                        desc: 'Attributes for the context'
+      class_option :skip_context, type: :boolean, desc: 'Whether or not to generate a context class'
 
       def create_organizer
         template 'organizer.erb', file_path

--- a/lib/rails/generators/interactor/rspec_generator.rb
+++ b/lib/rails/generators/interactor/rspec_generator.rb
@@ -15,7 +15,7 @@ module Interactor
       private
 
       def file_path
-        File.join('spec', interactor_dir, File.join(class_path), "#{file_name}_spec.rb")
+        File.join('spec', interactor_directory, File.join(class_path), "#{file_name}_spec.rb")
       end
     end
   end

--- a/lib/rails/generators/interactor/templates/context.erb
+++ b/lib/rails/generators/interactor/templates/context.erb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class <%= class_name %>Context < ApplicationContext
-  <%- unless context_attributes.empty? -%>
+<%- unless context_attributes.empty? -%>
   attributes <%= context_attributes.map { |a| ":#{a}" }.join(', ') %>
-  <%- end -%>
+<%- end -%>
 end

--- a/lib/rails/generators/interactor/templates/context.erb
+++ b/lib/rails/generators/interactor/templates/context.erb
@@ -1,4 +1,7 @@
 # frozen_string_literal: true
 
 class <%= class_name %>Context < ApplicationContext
+  <%- unless context_attributes.empty? -%>
+  attributes <%= context_attributes.map { |a| ":#{a}" }.join(', ') %>
+  <%- end -%>
 end

--- a/lib/rails/generators/interactor/templates/interactor.erb
+++ b/lib/rails/generators/interactor/templates/interactor.erb
@@ -2,6 +2,10 @@
 
 class <%= class_name %> < ApplicationInteractor
 
+  <%- if skip_context? && !context_attributes.empty? -%>
+  context_attributes <%= context_attributes.map { |a| ":#{a}" }.join(', ') %>
+  <%- end -%>
+
   def perform
     # TODO implement <%= class_name %> call
   end

--- a/lib/rails/generators/interactor/templates/interactor.erb
+++ b/lib/rails/generators/interactor/templates/interactor.erb
@@ -1,11 +1,10 @@
 # frozen_string_literal: true
 
 class <%= class_name %> < ApplicationInteractor
-
-  <%- if skip_context? && !context_attributes.empty? -%>
+<%- if skip_context? && !context_attributes.empty? -%>
   context_attributes <%= context_attributes.map { |a| ":#{a}" }.join(', ') %>
-  <%- end -%>
 
+<%- end -%>
   def perform
     # TODO implement <%= class_name %> call
   end

--- a/lib/rails/generators/interactor/templates/organizer.erb
+++ b/lib/rails/generators/interactor/templates/organizer.erb
@@ -3,6 +3,7 @@
 class <%= class_name %> < ApplicationOrganizer
 <%- if skip_context? && !context_attributes.empty? -%>
   context_attributes <%= context_attributes.map { |a| ":#{a}" }.join(', ') %>
+
 <%- end -%>
 <%- if interactors.any? -%>
   organize <%= interactors.map(&:classify).join(", ") %>

--- a/lib/rails/generators/interactor/templates/organizer.erb
+++ b/lib/rails/generators/interactor/templates/organizer.erb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 class <%= class_name %> < ApplicationOrganizer
-
+<%- if skip_context? && !context_attributes.empty? -%>
+  context_attributes <%= context_attributes.map { |a| ":#{a}" }.join(', ') %>
+<%- end -%>
 <%- if interactors.any? -%>
   organize <%= interactors.map(&:classify).join(", ") %>
 <%- else -%>

--- a/lib/rails/generators/interactor/test_unit_generator.rb
+++ b/lib/rails/generators/interactor/test_unit_generator.rb
@@ -15,7 +15,7 @@ module Interactor
       private
 
       def file_path
-        File.join('test', interactor_dir, File.join(class_path), "#{file_name}_test.rb")
+        File.join('test', interactor_directory, File.join(class_path), "#{file_name}_test.rb")
       end
     end
   end


### PR DESCRIPTION
## Description

<!-- Summarize the pull request -->
Context generators will now accept a context attributes argument

## Information

- [ ] Contains Documentation
- [ ] Contains Tests
- [ ] Contains Breaking Changes

## Related Issues

<!-- besure to use the github action format for issues -->
<!-- <action> [issue_id] -->
<!-- i.e. "resloves #1" -->
<!-- delete this if there are no related issues -->
- resolves #97 

## Changelog

<!-- provide any changelog items this pull request implements -->
<!-- follow the keep a changelog format -->
<!-- see https://keepachangelog.com/en/1.0.0/ -->
<!-- delete any unused headings -->

### Added

- context_attributes arguments to interactor, organizer, and context generators
- skip-context argument to interactor, organizer, and context generators
