### PR TITLE
address duplication issues for configuration objects

### DIFF
--- a/lib/active_interactor/config.rb
+++ b/lib/active_interactor/config.rb
@@ -2,6 +2,8 @@
 
 require 'logger'
 
+require 'active_interactor/configurable'
+
 module ActiveInteractor
   # The ActiveInteractor configuration object
   # @author Aaron Allen <hello@aaronmallen.me>
@@ -9,21 +11,13 @@ module ActiveInteractor
   # @!attribute [rw] logger
   #  @return [Logger] an instance of Logger
   class Config
-    # @return [Hash{Symbol=>*}] the default configuration options
-    DEFAULTS = {
-      logger: Logger.new(STDOUT)
-    }.freeze
+    include Configurable
+    defaults logger: Logger.new(STDOUT)
 
-    attr_accessor :logger
-
+    # @!method initialize(options = {})
     # @param options [Hash] the options for the configuration
     # @option options [Logger] :logger the configuration logger instance
     # @return [Config] a new instance of {Config}
-    def initialize(options = {})
-      DEFAULTS.dup.merge(options).each do |key, value|
-        instance_variable_set("@#{key}", value)
-      end
-    end
 
     # The rails configuration object
     # @return [Rails::Config|nil] an instance of {Rails::Config} if `Rails` is

--- a/lib/active_interactor/configurable.rb
+++ b/lib/active_interactor/configurable.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'active_support/core_ext/class/attribute'
+
+module ActiveInteractor
+  # Methods for configurable objects
+  # @author Aaron Allen <hello@aaronmallen.me>
+  # @since 1.0.0
+  module Configurable
+    def self.included(base)
+      base.class_eval do
+        extend ClassMethods
+      end
+    end
+
+    # Class methods for configuable objects
+    module ClassMethods
+      # Set or get default options for a configurable object
+      # @param options [Hash] the options to set for defaults
+      # @return [Hash] the defaults
+      def defaults(options = {})
+        return __defaults if options.empty?
+
+        options.each do |key, value|
+          __defaults[key.to_sym] = value
+          send(:attr_accessor, key.to_sym)
+        end
+      end
+
+      private
+
+      def __defaults
+        @__defaults ||= {}
+      end
+    end
+
+    # @param options [Hash] the options for the configuration
+    # @return [Configurable] a new instance of {Configurable}
+    def initialize(options = {})
+      self.class.defaults.merge(options).each do |key, value|
+        instance_variable_set("@#{key}", value)
+      end
+    end
+  end
+end

--- a/lib/active_interactor/rails/config.rb
+++ b/lib/active_interactor/rails/config.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'active_interactor/configurable'
+
 module ActiveInteractor
   module Rails
     # The ActiveInteractor rails configuration object
@@ -11,24 +13,15 @@ module ActiveInteractor
     #  @return [Boolean] whether or not to generate a seperate
     #    context class for an interactor.
     class Config
-      # @return [Hash{Symbol=>*}] the default configuration options
-      DEFAULTS = {
-        directory: 'interactors',
-        generate_context_classes: true
-      }.freeze
+      include ActiveInteractor::Configurable
+      defaults directory: 'interactors', generate_context_classes: true
 
-      attr_accessor :directory, :generate_context_classes
-
+      # @!method initialize(options = {})
       # @param options [Hash] the options for the configuration
       # @option options [String] :directory (defaults to: 'interactors') the configuration directory property
       # @option options [Boolean] :generate_context_classes (defaults to: `true`) the configuration
       #   generate_context_class property.
       # @return [Config] a new instance of {Config}
-      def initialize(options = {})
-        DEFAULTS.dup.merge(options).each do |key, value|
-          instance_variable_set("@#{key}", value)
-        end
-      end
     end
   end
 end

--- a/spec/active_interactor/config_spec.rb
+++ b/spec/active_interactor/config_spec.rb
@@ -6,6 +6,14 @@ RSpec.describe ActiveInteractor::Config do
   subject { described_class.new }
   it { is_expected.to respond_to :logger }
 
+  describe '.defaults' do
+    subject { described_class.defaults }
+
+    it 'is expected to have attributes :logger => Logger.new' do
+      expect(subject[:logger]).to be_a Logger
+    end
+  end
+
   describe '.rails' do
     subject { described_class.new.rails }
 

--- a/spec/active_interactor/rails/config_spec.rb
+++ b/spec/active_interactor/rails/config_spec.rb
@@ -8,4 +8,16 @@ RSpec.describe ActiveInteractor::Rails::Config do
 
   it { is_expected.to respond_to :directory }
   it { is_expected.to respond_to :generate_context_classes }
+
+  describe '.defaults' do
+    subject { described_class.defaults }
+
+    it 'is expected to have attributes :directory => "interactors"' do
+      expect(subject[:directory]).to eq 'interactors'
+    end
+
+    it 'is expected to have attributes :generate_context_classes => true' do
+      expect(subject[:generate_context_classes]).to eq true
+    end
+  end
 end


### PR DESCRIPTION
## Description

<!-- Summarize the pull request -->
Address duplication issues for configuration objects

## Information

- [x] Contains Documentation
- [x] Contains Tests
- [ ] Contains Breaking Changes

## Related Issues

<!-- besure to use the github action format for issues -->
<!-- <action> [issue_id] -->
<!-- i.e. "resloves #1" -->
<!-- delete this if there are no related issues -->

## Changelog

<!-- provide any changelog items this pull request implements -->
<!-- follow the keep a changelog format -->
<!-- see https://keepachangelog.com/en/1.0.0/ -->
<!-- delete any unused headings -->

### Added

- `ActiveInteractor::Configurable`

### Removed

- `ActiveInteractor::Config::DEFAULTS` use `ActiveInteractor::Config.defaults` instead
- `ActiveInteractor::Rails::Config::DEFAULTS` use `ActiveInteractor::Rails::Config.defaults` instead