### PR TITLE
#36 Allow organized interactors to be skipped based on conditional options

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ see [v0.1.7](https://github.com/aaronmallen/activeinteractor/tree/0-1-stable)**
     * [Kinds of Interactors](#kinds-of-interactors)
       * [Interactors](#interactors)
       * [Organizers](#organizers)
-      * [Parallel Organizers](#parallel-organizers)
+        * [Organizing Interactors Conditionally](#organizing-interactors-conditionally)
+        * [Running Interactors In Parallel](#running-interactors-in-parallel)
     * [Rollback](#rollback)
     * [Callbacks](#callbacks)
       * [Validation Callbacks](#validation-callbacks)
@@ -425,7 +426,27 @@ end
 The organizer passes its context to the interactors that it organizes, one at a time and in order. Each interactor may
 change that context before it's passed along to the next interactor.
 
-##### Parallel Organizers
+###### Organizing Interactors Conditionally
+
+We can also add conditional statements to our organizer by passing a block to the `#organize` method:
+
+```ruby
+class PlaceOrder < ActiveInteractor::Organizer
+  organize do
+    add :create_order, if :user_registered?
+    add :charge_card, if: -> { context.order_number }
+    add :send_thank_you, if: -> { context.order_number }
+  end
+
+  private
+
+  def user_registered?
+    context.user&.registered?
+  end
+end
+```
+
+###### Running Interactors In Parallel
 
 Organizers can be told to run their interactors in parallel with the `#perform_in_parallel` class method.  This
 will run each interactor in parallel with one and other only passing the original context to each organizer.

--- a/lib/active_interactor/organizer.rb
+++ b/lib/active_interactor/organizer.rb
@@ -1,16 +1,14 @@
 # frozen_string_literal: true
 
 require 'active_support/core_ext/class/attribute'
-require 'active_support/core_ext/string/inflections'
+
+require 'active_interactor/organizer/interactor_interface_collection'
 
 module ActiveInteractor
   # A base Organizer class.  All organizers should inherit from
   #  {Organizer}.
   # @author Aaron Allen <hello@aaronmallen.me>
   # @since 0.0.1
-  # @!attribute [r] organized
-  #  @!scope class
-  #  @return [Array<Base>] the organized interactors
   # @!attribute [r] parallel
   #  @since 1.0.0
   #  @!scope class
@@ -36,7 +34,6 @@ module ActiveInteractor
   #  MyOrganizer.perform
   #  #=> <MyOrganizer::Context interactor1=true interactor2=true>
   class Organizer < Base
-    class_attribute :organized, instance_writer: false, default: []
     class_attribute :parallel, instance_writer: false, default: false
     define_callbacks :each_perform
 
@@ -83,7 +80,6 @@ module ActiveInteractor
 
     # Define a callback to call around each organized interactor's
     #  {Base.perform} has been invokation
-    #
     # @example
     #  class MyInteractor1 < ActiveInteractor::Base
     #    before_perform :print_name
@@ -129,7 +125,6 @@ module ActiveInteractor
 
     # Define a callback to call before each organized interactor's
     #  {Base.perform} has been invoked
-    #
     # @example
     #  class MyInteractor1 < ActiveInteractor::Base
     #    before_perform :print_name
@@ -172,21 +167,50 @@ module ActiveInteractor
     # Declare Interactors to be invoked as part of the
     #  organizer's invocation. These interactors are invoked in
     #  the order in which they are declared
-    #
-    # @example
-    #   class MyFirstOrganizer < ActiveInteractor::Organizer
-    #     organize InteractorOne, InteractorTwo
+    # @example Basic interactor organization
+    #   class MyOrganizer < ActiveInteractor::Organizer
+    #     organize :interactor_one, :interactor_two
     #   end
-    #
-    #   class MySecondOrganizer < ActiveInteractor::Organizer
-    #     organize [InteractorThree, InteractorFour]
+    # @example Conditional interactor organization with block
+    #   class MyOrganizer < ActiveInteractor::Organizer
+    #     organize do
+    #       add :interactor_one
+    #       add :interactor_two, if: -> { context.valid? }
+    #     end
     #   end
+    # @example Conditional interactor organization with method
+    #   class MyOrganizer < ActiveInteractor::Organizer
+    #     organize do
+    #       add :interactor_one
+    #       add :interactor_two, unless: :invalid_context?
+    #     end
     #
-    # @param interactors [Array<Base>] the interactors to call
-    def self.organize(*interactors)
-      self.organized = interactors.flatten.map do |interactor|
-        interactor.to_s.classify.safe_constantize
-      end.compact
+    #     private
+    #
+    #     def invalid_context?
+    #       !context.valid?
+    #     end
+    #   end
+    # @example Interactor organization with perform options
+    #   class MyOrganizer < ActiveInteractor::Organizer
+    #     organize do
+    #       add :interactor_one, validate: false
+    #       add :interactor_two, skip_perform_callbacks: true
+    #     end
+    #   end
+    # @param interactors [Array<Base|Symbol|String>] the interactors to call
+    # @yield [.organized] if block given
+    # @return [InteractorInterfaceCollection] an instance of {InteractorInterfaceCollection}
+    def self.organize(*interactors, &block)
+      organized.concat(interactors) if interactors
+      organized.instance_eval(&block) if block
+      organized
+    end
+
+    # Organized interactors
+    # @return [InteractorInterfaceCollection] an instance of {InteractorInterfaceCollection}
+    def self.organized
+      @organized ||= InteractorInterfaceCollection.new
     end
 
     # Run organized interactors in parallel
@@ -196,7 +220,7 @@ module ActiveInteractor
     end
 
     # Invoke the organized interactors. An organizer is
-    #  expected not to define its own {Base#perform} method
+    #  expected not to define its own {Interactor#perform #perform} method
     #  in favor of this default implementation.
     def perform
       if self.class.parallel
@@ -208,11 +232,9 @@ module ActiveInteractor
 
     private
 
-    def execute_interactor_with_callbacks(interactor, fail_on_error = false, execute_options = {})
+    def execute_interactor_with_callbacks(interface, fail_on_error = false, perform_options = {})
       run_callbacks :each_perform do
-        instance = interactor.new(context)
-        method = fail_on_error ? :execute_perform! : :execute_perform
-        instance.send(method, execute_options)
+        interface.perform(self, context, fail_on_error, perform_options)
       end
     end
 
@@ -222,16 +244,17 @@ module ActiveInteractor
     end
 
     def perform_in_order
-      self.class.organized.each do |interactor|
-        context.merge!(execute_interactor_with_callbacks(interactor, true))
+      self.class.organized.each do |interface|
+        result = execute_interactor_with_callbacks(interface, true)
+        context.merge!(result) if result
       end
     rescue Error::ContextFailure => e
       context.merge!(e.context)
     end
 
     def perform_in_parallel
-      results = self.class.organized.map do |interactor|
-        Thread.new { execute_interactor_with_callbacks(interactor, false, skip_rollback: true) }
+      results = self.class.organized.map do |interface|
+        Thread.new { execute_interactor_with_callbacks(interface, false, skip_rollback: true) }
       end
       merge_contexts(results.map(&:value))
     end

--- a/lib/active_interactor/organizer/interactor_interface.rb
+++ b/lib/active_interactor/organizer/interactor_interface.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require 'active_support/core_ext/string/inflections'
+
+module ActiveInteractor
+  class Organizer < ActiveInteractor::Base
+    # @api private
+    # An interface for an interactor's to allow conditional invokation of an
+    #  interactor's {Interactor#perform #perform} method.
+    # @author Aaron Allen <hello@aaronmallen.me>
+    # @since 1.0.0
+    # @!attribute [r] filters
+    #  @return [Hash{Symbol=>*}] conditional filters for an interactor's
+    #    {Interactor#perform #perform} invocation.
+    # @!attribute [r] interactor_class
+    #  @return [Class] an interactor class
+    # @!attribute [r] perform_options
+    #  @return [Hash{Symbol=>*}] perform options to use for an interactor's
+    #    {Interactor#perform #perform} invocation.
+    class InteractorInterface
+      attr_reader :filters, :interactor_class, :perform_options
+
+      # @return [Array<Symbol>] keywords that indicate an option is a
+      #  conditional.
+      CONDITIONAL_FILTERS = %i[if unless].freeze
+
+      # @param interactor_class [Class|Symbol|String] the {.interactor_class}
+      # @param options [Hash{Symbol=>*}] the {.filters} and {.perform_options}
+      # @return [InteractorInterface|nil] a new instance of {InteractorInterface} if
+      #  the {#interactor_class} exists
+      def initialize(interactor_class, options = {})
+        @interactor_class = interactor_class.to_s.classify.safe_constantize
+        @filters = options.select { |key, _value| CONDITIONAL_FILTERS.include?(key) }
+        @perform_options = options.reject { |key, _value| CONDITIONAL_FILTERS.include?(key) }
+      end
+
+      # Check conditional filters on an interactor and invoke it's {Interactor#perform #perform}
+      #  method if conditions are met.
+      # @param target [Class] an instance of {Organizer}
+      # @param context [Context::Base] the organizer's {Context::Base context} instance
+      # @param fail_on_error [Boolean] if `true` {Interactor::Worker#execute_perform! #execute_perform!}
+      #  will be invoked on the interactor. If `false` {Interactor::Worker#execute_perform #execute_perform}
+      #  will be invokded on the interactor.
+      # @param perform_options [Hash{Symbol=>*}] additional options to be merged into {#perform_options}
+      # @return [Context::Base|nil] an instance of {Context::Base} if an interactor's
+      #   {Interactor#perform #perform} is invoked
+      def perform(target, context, fail_on_error = false, perform_options = {})
+        return if check_conditionals(target, filters[:if]) == false
+        return if check_conditionals(target, filters[:unless]) == true
+
+        method = fail_on_error ? :execute_perform! : :execute_perform
+        options = self.perform_options.merge(perform_options)
+        interactor_class.new(context).send(method, options)
+      end
+
+      private
+
+      def check_conditionals(target, filter)
+        return unless filter
+
+        return target.send(filter) if filter.is_a?(Symbol)
+        return target.instance_exec(&filter) if filter.is_a?(Proc)
+      end
+    end
+  end
+end

--- a/lib/active_interactor/organizer/interactor_interface_collection.rb
+++ b/lib/active_interactor/organizer/interactor_interface_collection.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require 'active_interactor/organizer/interactor_interface'
+
+module ActiveInteractor
+  class Organizer < ActiveInteractor::Base
+    # @api private
+    # A collection of ordered interactors for an {Organizer}
+    # @author Aaron Allen <hello@aaronmallen.me>
+    # @since 1.0.0
+    # @!attribute [r] collection
+    #  @return [Array<Hash{Symbol=>*}] the organized interactors and filters
+    class InteractorInterfaceCollection
+      attr_reader :collection
+
+      # @!method each(&block)
+      # Calls the given block once for each element of {#collection}, passing that
+      #  element as a parameter
+      # @yield [.collection] the {#collection}
+      # @return [Array<InteractorInterface>] the {#collection}
+
+      # @!method map(&block)
+      # Invokes the given block once fore each element of {#collection}.
+      # @yield [.collection] the {#collection}
+      # @return [Array] a new array containing the values returned by the block.
+      delegate :each, :map, to: :collection
+
+      # @return [InteractorInterfaceCollection] a new instance of {InteractorInterfaceCollection}
+      def initialize
+        @collection = []
+      end
+
+      # Add an {InteractorInterface} to the {#collection}
+      # @param interactor [Class|Symbol|String] an interactor class name
+      # @param filters [Hash{Symbol=>*}] conditions and {Interactor::PerformOptions} for the interactor
+      # @option filters [Symbol|Proc] :if only invoke the interactor's perform method
+      #   if method or block returns `true`
+      # @option filters [Symbol|Proc] :unless only invoke the interactor's perform method
+      #   if method or block returns `false`
+      # @see Interactor::PerformOptions
+      # @return [InteractorInterface] the {InteractorInterface} instance
+      def add(interactor, filters = {})
+        interface = InteractorInterface.new(interactor, filters)
+        collection << interface if interface.interactor_class
+        self
+      end
+
+      # Concat multiple {InteractorInterface} to the {#collection}
+      # @param interactors [Array<Class>] the interactor classes to add
+      #  to the collection
+      # @return [InteractorInterface] the {InteractorInterface} instance
+      def concat(interactors)
+        interactors.flatten.each { |interactor| add(interactor) }
+        self
+      end
+    end
+  end
+end

--- a/spec/active_interactor/organizer/interactor_interface_collection_spec.rb
+++ b/spec/active_interactor/organizer/interactor_interface_collection_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe ActiveInteractor::Organizer::InteractorInterfaceCollection do
+  describe '#add' do
+    subject { instance.add(interactor) }
+    let(:instance) { described_class.new }
+
+    context 'with an interactor that does not exist' do
+      let(:interactor) { :an_interactor_that_does_not_exist }
+
+      it { expect { subject }.not_to(change { instance.collection.count }) }
+      it { is_expected.to be_a described_class }
+    end
+
+    context 'with an existing interactor' do
+      before { build_interactor }
+
+      context 'when interactors are passed as contants' do
+        let(:interactor) { TestInteractor }
+
+        it { expect { subject }.to change { instance.collection.count }.by(1) }
+        it { is_expected.to be_a described_class }
+
+        it 'is expected to add the appropriate interactor' do
+          subject
+          expect(instance.collection.first.interactor_class).to eq TestInteractor
+        end
+      end
+
+      context 'when interactors are passed as symbols' do
+        let(:interactor) { :test_interactor }
+
+        it { expect { subject }.to change { instance.collection.count }.by(1) }
+        it { is_expected.to be_a described_class }
+
+        it 'is expected to add the appropriate interactor' do
+          subject
+          expect(instance.collection.first.interactor_class).to eq TestInteractor
+        end
+      end
+
+      context 'when interactors are passed as strings' do
+        let(:interactor) { 'TestInteractor' }
+
+        it { expect { subject }.to change { instance.collection.count }.by(1) }
+        it { is_expected.to be_a described_class }
+
+        it 'is expected to add the appropriate interactor' do
+          subject
+          expect(instance.collection.first.interactor_class).to eq TestInteractor
+        end
+      end
+    end
+  end
+
+  describe '#concat' do
+    subject { instance.concat(interactors) }
+    let(:instance) { described_class.new }
+
+    context 'with two existing interactors' do
+      let!(:interactor1) { build_interactor('TestInteractor1') }
+      let!(:interactor2) { build_interactor('TestInteractor2') }
+      let(:interactors) { %i[test_interactor_1 test_interactor_2] }
+
+      it { expect { subject }.to change { instance.collection.count }.by(2) }
+
+      it 'is expected to add the appropriate interactors' do
+        subject
+        expect(instance.collection.first.interactor_class).to eq TestInteractor1
+        expect(instance.collection.last.interactor_class).to eq TestInteractor2
+      end
+    end
+  end
+end

--- a/spec/active_interactor/organizer/interactor_interface_spec.rb
+++ b/spec/active_interactor/organizer/interactor_interface_spec.rb
@@ -1,0 +1,162 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe ActiveInteractor::Organizer::InteractorInterface do
+  describe '.new' do
+    subject(:instance) { described_class.new(interactor_class, options) }
+
+    context 'with an interactor that does not exist' do
+      let(:interactor_class) { :an_interactor_that_does_not_exist }
+      let(:options) { {} }
+
+      describe '#interactor_class' do
+        subject { instance.interactor_class }
+
+        it { is_expected.to be_nil }
+      end
+    end
+
+    RSpec.shared_examples 'an instance of InteractorInterface correctly parse options' do
+      context 'with options {:if => :some_method }' do
+        let(:options) { { if: :some_method } }
+
+        describe '#filters' do
+          subject { instance.filters }
+
+          it { is_expected.to eq(if: :some_method) }
+        end
+
+        describe '#perform_options' do
+          subject { instance.perform_options }
+
+          it { is_expected.to be_empty }
+        end
+      end
+
+      context 'with options {:if => -> { context.test == true } }' do
+        let(:options) { { if: -> { context.test == true } } }
+
+        describe '#filters' do
+          subject { instance.filters }
+
+          it { expect(subject[:if]).not_to be_nil }
+          it { expect(subject[:if]).to be_a Proc }
+        end
+
+        describe '#perform_options' do
+          subject { instance.perform_options }
+
+          it { is_expected.to be_empty }
+        end
+      end
+
+      context 'with options {:unless => :some_method }' do
+        let(:options) { { unless: :some_method } }
+
+        describe '#filters' do
+          subject { instance.filters }
+
+          it { is_expected.to eq(unless: :some_method) }
+        end
+
+        describe '#perform_options' do
+          subject { instance.perform_options }
+
+          it { is_expected.to be_empty }
+        end
+      end
+
+      context 'with options {:unless => -> { context.test == true } }' do
+        let(:options) { { unless: -> { context.test == true } } }
+
+        describe '#filters' do
+          subject { instance.filters }
+
+          it { expect(subject[:unless]).not_to be_nil }
+          it { expect(subject[:unless]).to be_a Proc }
+        end
+
+        describe '#perform_options' do
+          subject { instance.perform_options }
+
+          it { is_expected.to be_empty }
+        end
+      end
+
+      context 'with options { :validate => false }' do
+        let(:options) { { validate: false } }
+
+        describe '#filters' do
+          subject { instance.filters }
+
+          it { is_expected.to be_empty }
+        end
+
+        describe '#perform_options' do
+          subject { instance.perform_options }
+
+          it { is_expected.to eq(validate: false) }
+        end
+      end
+
+      context 'with options { :if => :some_method, :validate => false }' do
+        let(:options) { { if: :some_method, validate: false } }
+
+        describe '#filters' do
+          subject { instance.filters }
+
+          it { is_expected.to eq(if: :some_method) }
+        end
+
+        describe '#perform_options' do
+          subject { instance.perform_options }
+
+          it { is_expected.to eq(validate: false) }
+        end
+      end
+    end
+
+    context 'with an existing interactor' do
+      before { build_interactor }
+
+      context 'when interactors are passed as contants' do
+        let(:interactor_class) { TestInteractor }
+        let(:options) { {} }
+
+        include_examples 'an instance of InteractorInterface correctly parse options'
+
+        describe '#interactor_class' do
+          subject { instance.interactor_class }
+
+          it { is_expected.to eq TestInteractor }
+        end
+      end
+
+      context 'when interactors are passed as symbols' do
+        let(:interactor_class) { :test_interactor }
+        let(:options) { {} }
+
+        include_examples 'an instance of InteractorInterface correctly parse options'
+
+        describe '#interactor_class' do
+          subject { instance.interactor_class }
+
+          it { is_expected.to eq TestInteractor }
+        end
+      end
+
+      context 'when interactors are passed as strings' do
+        let(:interactor_class) { 'TestInteractor' }
+        let(:options) { {} }
+        include_examples 'an instance of InteractorInterface correctly parse options'
+
+        describe '#interactor_class' do
+          subject { instance.interactor_class }
+
+          it { is_expected.to eq TestInteractor }
+        end
+      end
+    end
+  end
+end

--- a/spec/active_interactor/organizer_spec.rb
+++ b/spec/active_interactor/organizer_spec.rb
@@ -51,58 +51,46 @@ RSpec.describe ActiveInteractor::Organizer do
   end
 
   describe '.organize' do
-    subject { interactor_class }
     context 'with two existing interactors' do
       let!(:interactor1) { build_interactor('TestInteractor1') }
       let!(:interactor2) { build_interactor('TestInteractor2') }
 
-      context 'when interactors are passed as contants' do
-        let(:interactor_class) do
-          build_organizer do
-            organize TestInteractor1, TestInteractor2
-          end
-        end
-
-        it { is_expected.to have_attributes(organized: [TestInteractor1, TestInteractor2]) }
-      end
-
-      context 'when interactors are passed as symbols' do
-        let(:interactor_class) do
+      context 'when interactors are passed as args' do
+        let(:organizer) do
           build_organizer do
             organize :test_interactor_1, :test_interactor_2
           end
         end
 
-        it { is_expected.to have_attributes(organized: [TestInteractor1, TestInteractor2]) }
+        describe '.organized' do
+          subject { organizer.organized }
 
-        context 'having a non existance interactor' do
-          let(:interactor_class) do
-            build_organizer do
-              organize :test_interactor_1, :interactor_that_doesnt_exist, :test_interactor_2
-            end
+          it { expect(subject.collection).to all(be_a ActiveInteractor::Organizer::InteractorInterface) }
+          it 'is expected to organize the approriate interactors' do
+            expect(subject.collection.first.interactor_class).to eq TestInteractor1
+            expect(subject.collection.last.interactor_class).to eq TestInteractor2
           end
-
-          it { is_expected.to have_attributes(organized: [TestInteractor1, TestInteractor2]) }
         end
       end
 
-      context 'when interactors are passed as strings' do
-        let(:interactor_class) do
+      context 'when a block is passed' do
+        let(:organizer) do
           build_organizer do
-            organize 'TestInteractor1', 'TestInteractor2'
+            organize do
+              add :test_interactor_1
+              add :test_interactor_2
+            end
           end
         end
 
-        it { is_expected.to have_attributes(organized: [TestInteractor1, TestInteractor2]) }
+        describe '.organized' do
+          subject { organizer.organized }
 
-        context 'having a non existance interactor' do
-          let(:interactor_class) do
-            build_organizer do
-              organize 'TestInteractor1', 'InteractorThatDoesntExist', 'TestInteractor2'
-            end
+          it { expect(subject.collection).to all(be_a ActiveInteractor::Organizer::InteractorInterface) }
+          it 'is expected to organize the approriate interactors' do
+            expect(subject.collection.first.interactor_class).to eq TestInteractor1
+            expect(subject.collection.last.interactor_class).to eq TestInteractor2
           end
-
-          it { is_expected.to have_attributes(organized: [TestInteractor1, TestInteractor2]) }
         end
       end
     end

--- a/spec/integration/basic_integration_spec.rb
+++ b/spec/integration/basic_integration_spec.rb
@@ -115,12 +115,6 @@ RSpec.describe 'Basic Integration', type: :integration do
       it { is_expected.to be < ActiveInteractor::Context::Base }
     end
 
-    describe '.organized' do
-      subject { interactor_class.organized }
-
-      it { is_expected.to eq [TestInteractor1, TestInteractor2] }
-    end
-
     describe '.perform' do
       subject { interactor_class.perform }
 
@@ -254,18 +248,323 @@ RSpec.describe 'Basic Integration', type: :integration do
       it { is_expected.to be < ActiveInteractor::Context::Base }
     end
 
-    describe '.organized' do
-      subject { interactor_class.organized }
-
-      it { is_expected.to eq [TestInteractor1, TestInteractor2] }
-    end
-
     describe '.perform' do
       subject { interactor_class.perform }
 
       it { is_expected.to be_a interactor_class.context_class }
       it { is_expected.to be_successful }
       it { is_expected.to have_attributes(test_field_1: 'test 1', test_field_2: 'test 2') }
+    end
+  end
+
+  describe 'A basic with conditionally organized interactors' do
+    let!(:test_interactor_1) { build_interactor('TestInteractor1') }
+    let!(:test_interactor_2)  { build_interactor('TestInteractor2') }
+
+    context 'with a condition on the first interactor { :if => -> { context.test_1 } } ' \
+    'and a condition on the second interactor { :if => -> { context.test_2 } }' do
+      let(:interactor_class) do
+        build_organizer do
+          organize do
+            add :test_interactor_1, if: -> { context.test_1 }
+            add :test_interactor_2, if: -> { context.test_2 }
+          end
+        end
+      end
+
+      include_examples 'a class with interactor methods'
+      include_examples 'a class with interactor callback methods'
+      include_examples 'a class with interactor context methods'
+      include_examples 'a class with organizer callback methods'
+
+      describe '.perform' do
+        subject { interactor_class.perform(context_attributes) }
+
+        context 'with context_attributes test_1 and test_2 both eq to true' do
+          let(:context_attributes) { { test_1: true, test_2: true } }
+
+          it { is_expected.to be_a interactor_class.context_class }
+          it { is_expected.to be_successful }
+          it 'is expected to invoke #perform on both interactors' do
+            expect_any_instance_of(test_interactor_1).to receive(:perform)
+            expect_any_instance_of(test_interactor_2).to receive(:perform)
+            subject
+          end
+        end
+
+        context 'with context_attributes test_1 eq to true and test_2 eq to false' do
+          let(:context_attributes) { { test_1: true, test_2: false } }
+
+          it { is_expected.to be_a interactor_class.context_class }
+          it { is_expected.to be_successful }
+          it 'is expected to invoke #perform on the first interactor' do
+            expect_any_instance_of(test_interactor_1).to receive(:perform)
+            subject
+          end
+
+          it 'is expected not to invoke #perform on the first interactor' do
+            expect_any_instance_of(test_interactor_2).not_to receive(:perform)
+            subject
+          end
+        end
+
+        context 'with context_attributes test_1 eq to false and test_2 eq to true' do
+          let(:context_attributes) { { test_1: false, test_2: true } }
+
+          it { is_expected.to be_a interactor_class.context_class }
+          it { is_expected.to be_successful }
+          it 'is expected not to invoke #perform on the first interactor' do
+            expect_any_instance_of(test_interactor_1).not_to receive(:perform)
+            subject
+          end
+
+          it 'is expected to invoke #perform on the first interactor' do
+            expect_any_instance_of(test_interactor_2).to receive(:perform)
+            subject
+          end
+        end
+
+        context 'with context_attributes test_1 and test_2 both eq to false' do
+          let(:context_attributes) { { test_1: false, test_2: false } }
+
+          it { is_expected.to be_a interactor_class.context_class }
+          it { is_expected.to be_successful }
+          it 'is expected not to invoke #perform on the first interactor' do
+            expect_any_instance_of(test_interactor_1).not_to receive(:perform)
+            subject
+          end
+
+          it 'is expected not to invoke #perform on the first interactor' do
+            expect_any_instance_of(test_interactor_2).not_to receive(:perform)
+            subject
+          end
+        end
+      end
+    end
+
+    context 'with a condition on the first interactor { :unless => -> { context.test_1 } } ' \
+    'and a condition on the second interactor { :unless => -> { context.test_2 } }' do
+      let(:interactor_class) do
+        build_organizer do
+          organize do
+            add :test_interactor_1, unless: -> { context.test_1 }
+            add :test_interactor_2, unless: -> { context.test_2 }
+          end
+        end
+      end
+
+      include_examples 'a class with interactor methods'
+      include_examples 'a class with interactor callback methods'
+      include_examples 'a class with interactor context methods'
+      include_examples 'a class with organizer callback methods'
+
+      describe '.perform' do
+        subject { interactor_class.perform(context_attributes) }
+
+        context 'with context_attributes test_1 and test_2 both eq to true' do
+          let(:context_attributes) { { test_1: true, test_2: true } }
+
+          it { is_expected.to be_a interactor_class.context_class }
+          it { is_expected.to be_successful }
+          it 'is expected not to invoke #perform on the first interactor' do
+            expect_any_instance_of(test_interactor_1).not_to receive(:perform)
+            subject
+          end
+
+          it 'is expected not to invoke #perform on the second interactor' do
+            expect_any_instance_of(test_interactor_2).not_to receive(:perform)
+            subject
+          end
+        end
+
+        context 'with context_attributes test_1 eq to true and test_2 eq to false' do
+          let(:context_attributes) { { test_1: true, test_2: false } }
+
+          it { is_expected.to be_a interactor_class.context_class }
+          it { is_expected.to be_successful }
+          it 'is expected not to invoke #perform on the first interactor' do
+            expect_any_instance_of(test_interactor_1).not_to receive(:perform)
+            subject
+          end
+
+          it 'is expected to invoke #perform on the second interactor' do
+            expect_any_instance_of(test_interactor_2).to receive(:perform)
+            subject
+          end
+        end
+
+        context 'with context_attributes test_1 eq to false and test_2 eq to true' do
+          let(:context_attributes) { { test_1: false, test_2: true } }
+
+          it { is_expected.to be_a interactor_class.context_class }
+          it { is_expected.to be_successful }
+          it 'is expected to invoke #perform on the first interactor' do
+            expect_any_instance_of(test_interactor_1).to receive(:perform)
+            subject
+          end
+
+          it 'is expected not to invoke #perform on the second interactor' do
+            expect_any_instance_of(test_interactor_2).not_to receive(:perform)
+            subject
+          end
+        end
+
+        context 'with context_attributes test_1 and test_2 both eq to false' do
+          let(:context_attributes) { { test_1: false, test_2: false } }
+
+          it { is_expected.to be_a interactor_class.context_class }
+          it { is_expected.to be_successful }
+          it 'is expected to invoke #perform on both interactors' do
+            expect_any_instance_of(test_interactor_1).to receive(:perform)
+            expect_any_instance_of(test_interactor_2).to receive(:perform)
+            subject
+          end
+        end
+      end
+    end
+
+    context 'with a condition on the first interactor { :if => :test_method } and :test_method returning true' do
+      let(:interactor_class) do
+        build_organizer do
+          organize do
+            add :test_interactor_1, if: :test_method
+            add :test_interactor_2
+          end
+
+          private
+
+          def test_method
+            true
+          end
+        end
+      end
+
+      include_examples 'a class with interactor methods'
+      include_examples 'a class with interactor callback methods'
+      include_examples 'a class with interactor context methods'
+      include_examples 'a class with organizer callback methods'
+
+      describe '.perform' do
+        subject { interactor_class.perform }
+
+        it { is_expected.to be_a interactor_class.context_class }
+        it { is_expected.to be_successful }
+        it 'is expected to invoke #perform on both interactors' do
+          expect_any_instance_of(test_interactor_1).to receive(:perform)
+          expect_any_instance_of(test_interactor_2).to receive(:perform)
+          subject
+        end
+      end
+    end
+
+    context 'with a condition on the first interactor { :if => :test_method } and :test_method returning false' do
+      let(:interactor_class) do
+        build_organizer do
+          organize do
+            add :test_interactor_1, if: :test_method
+            add :test_interactor_2
+          end
+
+          private
+
+          def test_method
+            false
+          end
+        end
+      end
+
+      include_examples 'a class with interactor methods'
+      include_examples 'a class with interactor callback methods'
+      include_examples 'a class with interactor context methods'
+      include_examples 'a class with organizer callback methods'
+
+      describe '.perform' do
+        subject { interactor_class.perform }
+
+        it { is_expected.to be_a interactor_class.context_class }
+        it { is_expected.to be_successful }
+        it 'is expected not to invoke #perform on the first interactor' do
+          expect_any_instance_of(test_interactor_1).not_to receive(:perform)
+          subject
+        end
+
+        it 'is expected to invoke #perform on the second interactor' do
+          expect_any_instance_of(test_interactor_2).to receive(:perform)
+          subject
+        end
+      end
+    end
+
+    context 'with a condition on the first interactor { :unless => :test_method } and :test_method returning true' do
+      let(:interactor_class) do
+        build_organizer do
+          organize do
+            add :test_interactor_1, unless: :test_method
+            add :test_interactor_2
+          end
+
+          private
+
+          def test_method
+            true
+          end
+        end
+      end
+
+      include_examples 'a class with interactor methods'
+      include_examples 'a class with interactor callback methods'
+      include_examples 'a class with interactor context methods'
+      include_examples 'a class with organizer callback methods'
+
+      describe '.perform' do
+        subject { interactor_class.perform }
+
+        it { is_expected.to be_a interactor_class.context_class }
+        it { is_expected.to be_successful }
+        it 'is expected not to invoke #perform on the first interactor' do
+          expect_any_instance_of(test_interactor_1).not_to receive(:perform)
+          subject
+        end
+
+        it 'is expected to invoke #perform on the second interactor' do
+          expect_any_instance_of(test_interactor_2).to receive(:perform)
+          subject
+        end
+      end
+    end
+
+    context 'with a condition on the first interactor { :unless => :test_method } and :test_method returning false' do
+      let(:interactor_class) do
+        build_organizer do
+          organize do
+            add :test_interactor_1, unless: :test_method
+            add :test_interactor_2
+          end
+
+          private
+
+          def test_method
+            false
+          end
+        end
+      end
+
+      include_examples 'a class with interactor methods'
+      include_examples 'a class with interactor callback methods'
+      include_examples 'a class with interactor context methods'
+      include_examples 'a class with organizer callback methods'
+
+      describe '.perform' do
+        subject { interactor_class.perform }
+
+        it { is_expected.to be_a interactor_class.context_class }
+        it { is_expected.to be_successful }
+        it 'is expected to invoke #perform on both interactors' do
+          expect_any_instance_of(test_interactor_1).to receive(:perform)
+          expect_any_instance_of(test_interactor_2).to receive(:perform)
+          subject
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## Description

<!-- Summarize the pull request -->
Allow organized interactors to be skipped based on conditional options

## Information

- [x] Contains Documentation
- [x] Contains Tests
- [ ] Contains Breaking Changes

## Related Issues

<!-- besure to use the github action format for issues -->
<!-- <action> [issue_id] -->
<!-- i.e. "resloves #1" -->
<!-- delete this if there are no related issues -->
- resolves #36

## Changelog

<!-- provide any changelog items this pull request implements -->
<!-- follow the keep a changelog format -->
<!-- see https://keepachangelog.com/en/1.0.0/ -->
<!-- delete any unused headings -->

### Added

- `ActiveInteractor::Organizer::InteractorInterface`
- `ActiveInteractor::Organizer::InteractorInterfaceCollection`