### PR TITLE
remove after(:each) in context/base_spec

### DIFF
--- a/spec/active_interactor/context/base_spec.rb
+++ b/spec/active_interactor/context/base_spec.rb
@@ -3,8 +3,6 @@
 require 'spec_helper'
 
 RSpec.describe ActiveInteractor::Context::Base do
-  after(:each) { described_class.instance_variable_set('@__attributes', []) }
-
   describe '.attributes' do
     context 'when no arguments are passed' do
       subject { context_class.attributes }


### PR DESCRIPTION
## Description

<!-- Summarize the pull request -->
remove `after(:each)` in `context/base_spec`

## Information

- [ ] Contains Documentation
- [ ] Contains Tests
- [ ] Contains Breaking Changes

## Related Issues

<!-- besure to use the github action format for issues -->
<!-- <action> [issue_id] -->
<!-- i.e. "resloves #1" -->
<!-- delete this if there are no related issues -->
- resolves #145

## Changelog

<!-- provide any changelog items this pull request implements -->
<!-- follow the keep a changelog format -->
<!-- see https://keepachangelog.com/en/1.0.0/ -->
<!-- delete any unused headings -->