### PR TITLE
Use camelize instead of classify to safe_constantize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning].
 
 ## [Unreleased]
 
+### Fixed
+
+- [\#168](https://github.com/aaronmallen/activeinteractor/issues/168) `#classify` is called on const arguments
+
 ## [v1.0.2] - 2020-02-04
 
 ### Added

--- a/lib/active_interactor/context/loader.rb
+++ b/lib/active_interactor/context/loader.rb
@@ -22,7 +22,7 @@ module ActiveInteractor
       # @param interactor_class [Const] an {ActiveInteractor::Base interactor} class
       # @return [Const] a class that inherits from {Base}
       def self.create(context_class_name, interactor_class)
-        interactor_class.const_set(context_class_name.to_s.classify, Class.new(BASE_CONTEXT))
+        interactor_class.const_set(context_class_name.to_s.camelize, Class.new(BASE_CONTEXT))
       end
 
       # Find or create a {Base context} class for a given {ActiveInteractor::Base interactor}. If a class exists

--- a/lib/active_interactor/interactor/context.rb
+++ b/lib/active_interactor/interactor/context.rb
@@ -211,7 +211,7 @@ module ActiveInteractor
         # @return [Const] the {Base interactor} class' {ActiveInteractor::Context::Base context} class
         def contextualize_with(klass)
           @context_class = begin
-            context_class = klass.to_s.classify.safe_constantize
+            context_class = klass.to_s.camelize.safe_constantize
             raise(ActiveInteractor::Error::InvalidContextClass, klass) unless context_class
 
             context_class

--- a/lib/active_interactor/organizer/interactor_interface.rb
+++ b/lib/active_interactor/organizer/interactor_interface.rb
@@ -40,7 +40,7 @@ module ActiveInteractor
       #  {Interactor::Perform::ClassMethods#perform .perform}. See {Interactor::Perform::Options}.
       # @return [InteractorInterface] a new instance of {InteractorInterface}
       def initialize(interactor_class, options = {})
-        @interactor_class = interactor_class.to_s.classify.safe_constantize
+        @interactor_class = interactor_class.to_s.camelize.safe_constantize
         @filters = options.select { |key, _value| CONDITIONAL_FILTERS.include?(key) }
         @perform_options = options.reject { |key, _value| CONDITIONAL_FILTERS.include?(key) }
       end

--- a/lib/rails/generators/templates/organizer.erb
+++ b/lib/rails/generators/templates/organizer.erb
@@ -6,8 +6,8 @@ class <%= class_name %> < ApplicationOrganizer
 
 <%- end -%>
 <%- if interactors.any? -%>
-  organize <%= interactors.map(&:classify).join(", ") %>
+  organize <%= interactors.join(", ") %>
 <%- else -%>
-  # organize Interactor1, Interactor2
+  # organize :interactor_1, :interactor_2
 <%- end -%>
 end

--- a/spec/active_interactor/base_spec.rb
+++ b/spec/active_interactor/base_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe ActiveInteractor::Base do
 
   describe '.contextualize_with' do
     subject { described_class.contextualize_with(klass) }
-    let!(:singularized_class) { build_class('PlaceData') }
 
     context 'with an class that does not exist' do
       let(:klass) { 'SomeClassThatDoesNotExist' }
@@ -31,6 +30,7 @@ RSpec.describe ActiveInteractor::Base do
 
         # https://github.com/aaronmallen/activeinteractor/issues/168
         context 'when singularized' do
+          let!(:singularized_class) { build_context('PlaceData') }
           let(:klass) { 'PlaceData' }
 
           it 'is expected to assign the appropriate context class' do
@@ -50,6 +50,7 @@ RSpec.describe ActiveInteractor::Base do
 
         # https://github.com/aaronmallen/activeinteractor/issues/168
         context 'when singularized' do
+          let!(:singularized_class) { build_context('PlaceData') }
           let(:klass) { :place_data }
 
           it 'is expected to assign the appropriate context class' do
@@ -69,6 +70,7 @@ RSpec.describe ActiveInteractor::Base do
 
         # https://github.com/aaronmallen/activeinteractor/issues/168
         context 'when singularized' do
+          let!(:singularized_class) { build_context('PlaceData') }
           let(:klass) { PlaceData }
 
           it 'is expected to assign the appropriate context class' do

--- a/spec/active_interactor/base_spec.rb
+++ b/spec/active_interactor/base_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe ActiveInteractor::Base do
 
   describe '.contextualize_with' do
     subject { described_class.contextualize_with(klass) }
+    let!(:singularized_class) { build_class('PlaceData') }
 
     context 'with an class that does not exist' do
       let(:klass) { 'SomeClassThatDoesNotExist' }
@@ -27,6 +28,16 @@ RSpec.describe ActiveInteractor::Base do
           subject
           expect(described_class.context_class).to eq TestContext
         end
+
+        # https://github.com/aaronmallen/activeinteractor/issues/168
+        context 'when singularized' do
+          let(:klass) { 'PlaceData' }
+
+          it 'is expected to assign the appropriate context class' do
+            subject
+            expect(described_class.context_class).to eq PlaceData
+          end
+        end
       end
 
       context 'when passed as a symbol' do
@@ -36,6 +47,16 @@ RSpec.describe ActiveInteractor::Base do
           subject
           expect(described_class.context_class).to eq TestContext
         end
+
+        # https://github.com/aaronmallen/activeinteractor/issues/168
+        context 'when singularized' do
+          let(:klass) { :place_data }
+
+          it 'is expected to assign the appropriate context class' do
+            subject
+            expect(described_class.context_class).to eq PlaceData
+          end
+        end
       end
 
       context 'when passed as a constant' do
@@ -44,6 +65,16 @@ RSpec.describe ActiveInteractor::Base do
         it 'is expected to assign the appropriate context class' do
           subject
           expect(described_class.context_class).to eq TestContext
+        end
+
+        # https://github.com/aaronmallen/activeinteractor/issues/168
+        context 'when singularized' do
+          let(:klass) { PlaceData }
+
+          it 'is expected to assign the appropriate context class' do
+            subject
+            expect(described_class.context_class).to eq PlaceData
+          end
         end
       end
     end


### PR DESCRIPTION
## Description

<!-- Summarize the pull request -->
Use `camelize` instead of `classify` to `safe_constantize` class names to prevent singularization of passed `Symbol` or `String` arguments.

## Information

- [ ] Contains Documentation
- [x] Contains Tests
- [ ] Contains Breaking Changes

## Related Issues

<!-- besure to use the github action format for issues -->
<!-- <action> [issue_id] -->
<!-- i.e. "resloves #1" -->
<!-- delete this if there are no related issues -->
- see #167
- see #168

## Changelog

<!-- provide any changelog items this pull request implements -->
<!-- follow the keep a changelog format -->
<!-- see https://keepachangelog.com/en/1.0.0/ -->
<!-- delete any unused headings -->

### Fixed

- #168 `#classify` is called on const arguments