### PR TITLE
[#169] Fix error persistence in organizers  

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,16 @@ and this project adheres to [Semantic Versioning].
 
 ## [Unreleased]
 
+### Added
+
+- `ActiveInteractor::Context::Errors`
+- `ActiveInteractor::Context::Status#resolve`
+
 ### Fixed
 
 - [\#168](https://github.com/aaronmallen/activeinteractor/issues/168) `#classify` is called on const arguments
+- [\#169](https://github.com/aaronmallen/activeinteractor/issues/169) If some of the interactors of the organizer fail
+  error message is not persisted.
 
 ## [v1.0.2] - 2020-02-04
 

--- a/lib/active_interactor.rb
+++ b/lib/active_interactor.rb
@@ -64,6 +64,7 @@ module ActiveInteractor
 
     autoload :Attributes
     autoload :Base
+    autoload :Errors
     autoload :Loader
     autoload :Status
   end

--- a/lib/active_interactor/context/attributes.rb
+++ b/lib/active_interactor/context/attributes.rb
@@ -50,7 +50,7 @@ module ActiveInteractor
       # @param context [Hash, Base, Class] attributes to assign to the {Base context}
       # @return [Base] a new instance of {Base}
       def initialize(context = {})
-        merge_errors!(context.errors) if context.respond_to?(:errors)
+        merge_errors!(context) if context.respond_to?(:errors)
         copy_flags!(context)
         copy_called!(context)
         context = context_attributes_as_hash(context) || {}
@@ -105,7 +105,7 @@ module ActiveInteractor
       # @param context [Class] a {Base context} instance to be merged
       # @return [self] the {Base context} instance
       def merge!(context)
-        merge_errors!(context.errors) if context.respond_to?(:errors)
+        merge_errors!(context) if context.respond_to?(:errors)
         copy_flags!(context)
         context.each_pair do |key, value|
           public_send("#{key}=", value) unless value.nil?
@@ -141,14 +141,6 @@ module ActiveInteractor
 
         context.each_pair do |key, value|
           public_send("#{key}=", value)
-        end
-      end
-
-      def merge_errors!(errors)
-        if errors.is_a? String
-          self.errors.add(:context, errors)
-        else
-          self.errors.merge!(errors)
         end
       end
     end

--- a/lib/active_interactor/context/base.rb
+++ b/lib/active_interactor/context/base.rb
@@ -326,6 +326,7 @@ module ActiveInteractor
       include ActiveModel::Attributes
       include ActiveModel::Validations
       include ActiveInteractor::Context::Attributes
+      include ActiveInteractor::Context::Errors
       include ActiveInteractor::Context::Status
     end
   end

--- a/lib/active_interactor/context/errors.rb
+++ b/lib/active_interactor/context/errors.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module ActiveInteractor
+  module Context
+    # Context error methods. Because {Errors} is a module classes should include {Errors} rather than
+    # inherit from it.
+    #
+    # @api private
+    # @author Aaron Allen <hello@aaronmallen.me>
+    # @since unreleased
+    module Errors
+      # Generic errors generated outside of validation.
+      #
+      # @return [ActiveModel::Errors] an instance of `ActiveModel::Errors`
+      def failure_errors
+        @failure_errors ||= ActiveModel::Errors.new(self)
+      end
+
+      private
+
+      def handle_errors(errors)
+        if errors.is_a?(String)
+          failure_errors.add(:context, errors)
+        else
+          failure_errors.merge!(errors)
+        end
+      end
+
+      def merge_errors!(other)
+        errors.merge!(other.errors)
+        failure_errors.merge!(other.errors)
+        failure_errors.merge!(other.failure_errors)
+      end
+
+      def resolve_errors
+        errors.merge!(failure_errors)
+      end
+    end
+  end
+end

--- a/lib/active_interactor/context/status.rb
+++ b/lib/active_interactor/context/status.rb
@@ -37,8 +37,9 @@ module ActiveInteractor
       # @see https://api.rubyonrails.org/classes/ActiveModel/Errors.html ActiveModel::Errors
       # @raise [Error::ContextFailure]
       def fail!(errors = nil)
-        merge_errors!(errors) if errors
+        handle_errors(errors) if errors
         @_failed = true
+        resolve
         raise ActiveInteractor::Error::ContextFailure, self
       end
 
@@ -58,6 +59,16 @@ module ActiveInteractor
         @_failed || false
       end
       alias fail? failure?
+
+      # Resolve an instance of {Base context}.  Called when an interactor
+      #  is finished with it's context.
+      #
+      # @since unreleased
+      # @return [self] the instance of {Base context}
+      def resolve
+        resolve_errors
+        self
+      end
 
       # {#rollback! Rollback} an instance of {Base context}. Any {ActiveInteractor::Base interactors} the instance has
       # been passed via the {#called!} method are asked to roll themselves back by invoking their

--- a/lib/active_interactor/interactor/context.rb
+++ b/lib/active_interactor/interactor/context.rb
@@ -366,6 +366,7 @@ module ActiveInteractor
       # @return [Class] the {ActiveInteractor::Context::Base context} instance
       def finalize_context!
         context.called!(self)
+        context.resolve
         context
       end
 

--- a/lib/active_interactor/models.rb
+++ b/lib/active_interactor/models.rb
@@ -40,6 +40,7 @@ module ActiveInteractor
         extend ActiveInteractor::Context::Attributes::ClassMethods
 
         include ActiveInteractor::Context::Attributes
+        include ActiveInteractor::Context::Errors
         include ActiveInteractor::Context::Status
         include ActiveInteractor::Models::InstanceMethods
         delegate :each_pair, to: :attributes

--- a/spec/active_interactor/context/base_spec.rb
+++ b/spec/active_interactor/context/base_spec.rb
@@ -127,7 +127,7 @@ RSpec.describe ActiveInteractor::Context::Base do
       it { expect { subject }.to raise_error(ActiveInteractor::Error::ContextFailure) }
 
       it 'is expected not to merge errors' do
-        expect(instance.errors).not_to receive(:merge!)
+        expect(instance.errors).not_to receive(:merge!).with(nil)
         subject
       rescue ActiveInteractor::Error::ContextFailure # rubocop:disable Lint/SuppressedException
       end

--- a/spec/integration/a_basic_organizer_spec.rb
+++ b/spec/integration/a_basic_organizer_spec.rb
@@ -69,6 +69,25 @@ RSpec.describe 'A basic organizer', type: :integration do
         expect_any_instance_of(test_interactor_2).not_to receive(:perform!)
         subject
       end
+
+      # https://github.com/aaronmallen/activeinteractor/issues/169
+      context 'with error message "something went wrong"' do
+        let!(:test_interactor_1) do
+          build_interactor('TestInteractor1') do
+            def perform
+              context.fail!('something went wrong')
+            end
+          end
+        end
+
+        it { expect { subject }.not_to raise_error }
+        it { is_expected.to be_a interactor_class.context_class }
+        it { is_expected.to be_failure }
+        it 'is expected to have errors "something went wrong" on :context' do
+          expect(subject.errors[:context]).not_to be_empty
+          expect(subject.errors[:context]).to include 'something went wrong'
+        end
+      end
     end
   end
 
@@ -91,6 +110,25 @@ RSpec.describe 'A basic organizer', type: :integration do
         expect_any_instance_of(test_interactor_2).to receive(:rollback)
         expect_any_instance_of(test_interactor_1).to receive(:rollback)
         subject
+      end
+
+      # https://github.com/aaronmallen/activeinteractor/issues/169
+      context 'with error message "something went wrong"' do
+        let!(:test_interactor_2) do
+          build_interactor('TestInteractor2') do
+            def perform
+              context.fail!('something went wrong')
+            end
+          end
+        end
+
+        it { expect { subject }.not_to raise_error }
+        it { is_expected.to be_a interactor_class.context_class }
+        it { is_expected.to be_failure }
+        it 'is expected to have errors "something went wrong" on :context' do
+          expect(subject.errors[:context]).not_to be_empty
+          expect(subject.errors[:context]).to include 'something went wrong'
+        end
       end
     end
   end


### PR DESCRIPTION
## Description

<!-- Summarize the pull request -->
Fix error persistence across context instances for organizers

## Information

- [x] Contains Documentation
- [x] Contains Tests
- [ ] Contains Breaking Changes

## Related Issues

<!-- besure to use the github action format for issues -->
<!-- <action> [issue_id] -->
<!-- i.e. "resloves #1" -->
<!-- delete this if there are no related issues -->
- see #169 

## Changelog

<!-- provide any changelog items this pull request implements -->
<!-- follow the keep a changelog format -->
<!-- see https://keepachangelog.com/en/1.0.0/ -->
<!-- delete any unused headings -->

### Added

- `ActiveInteractor::Context::Errors`
- `ActiveInteractor::Context::Status#resolve`

### Fixed

- #169 If some of the interactors of the organizer fail error message is not persisted.