### PR TITLE
Fix error message duplication

### DIFF
--- a/lib/active_interactor/context/errors.rb
+++ b/lib/active_interactor/context/errors.rb
@@ -18,6 +18,11 @@ module ActiveInteractor
 
       private
 
+      def clear_all_errors
+        errors.clear
+        failure_errors.clear
+      end
+
       def handle_errors(errors)
         if errors.is_a?(String)
           failure_errors.add(:context, errors)
@@ -33,7 +38,9 @@ module ActiveInteractor
       end
 
       def resolve_errors
-        errors.merge!(failure_errors)
+        all_errors = (failure_errors.uniq + errors.uniq).compact.uniq
+        clear_all_errors
+        all_errors.each { |error| errors.add(error[0], error[1]) }
       end
     end
   end

--- a/spec/integration/a_basic_organizer_spec.rb
+++ b/spec/integration/a_basic_organizer_spec.rb
@@ -83,6 +83,7 @@ RSpec.describe 'A basic organizer', type: :integration do
         it { expect { subject }.not_to raise_error }
         it { is_expected.to be_a interactor_class.context_class }
         it { is_expected.to be_failure }
+        it { expect(subject.errors.count).to eq 1 }
         it 'is expected to have errors "something went wrong" on :context' do
           expect(subject.errors[:context]).not_to be_empty
           expect(subject.errors[:context]).to include 'something went wrong'
@@ -125,6 +126,7 @@ RSpec.describe 'A basic organizer', type: :integration do
         it { expect { subject }.not_to raise_error }
         it { is_expected.to be_a interactor_class.context_class }
         it { is_expected.to be_failure }
+        it { expect(subject.errors.count).to eq 1 }
         it 'is expected to have errors "something went wrong" on :context' do
           expect(subject.errors[:context]).not_to be_empty
           expect(subject.errors[:context]).to include 'something went wrong'


### PR DESCRIPTION
## Description

<!-- Summarize the pull request -->
Ensure errors on a context are uniq

## Information

- [ ] Contains Documentation
- [x] Contains Tests
- [ ] Contains Breaking Changes

## Related Issues

<!-- besure to use the github action format for issues -->
<!-- <action> [issue_id] -->
<!-- i.e. "resloves #1" -->
<!-- delete this if there are no related issues -->
- see #184 

## Changelog

<!-- provide any changelog items this pull request implements -->
<!-- follow the keep a changelog format -->
<!-- see https://keepachangelog.com/en/1.0.0/ -->
<!-- delete any unused headings -->

### Fixed

- #184 Context.fail! error message gets pupulated 3 times with the same message