### PR TITLE
[AI-31] ensure we pass include_private to respond_to?

### DIFF
--- a/lib/active_interactor/result.rb
+++ b/lib/active_interactor/result.rb
@@ -80,7 +80,7 @@ module ActiveInteractor
 
     # @private
     def respond_to_missing?(method, include_private = false)
-      return super unless context.respond_to?(method)
+      return super unless context.respond_to?(method, include_private)
 
       context_method_deprecation_warning(method)
       context.respond_to?(method, include_private)


### PR DESCRIPTION
## Description

<!-- Summarize the pull request -->
ensure we pass`include_private` to `respond_to?`

## Information

- [ ] Contains Documentation
- [ ] Contains Tests
- [ ] Contains Breaking Changes

## Related Issues

<!-- besure to use the github action format for issues -->
<!-- <action> [issue_id] -->
<!-- i.e. "resloves #1" -->
<!-- delete this if there are no related issues -->
- fixes [AI-31]

## Changelog

<!-- provide any changelog items this pull request implements -->
<!-- follow the keep a changelog format -->
<!-- see https://keepachangelog.com/en/1.0.0/ -->
<!-- delete any unused headings -->

### Fixed

- `respond_to?` is false for private `context` methods on `ActiveInteractor::Result`

[AI-31]: https://aaronmallen.atlassian.net/browse/AI-31