### PR TITLE
Allow nested Organizers to fail parent organizer context

### DIFF
--- a/lib/active_interactor/organizer/perform.rb
+++ b/lib/active_interactor/organizer/perform.rb
@@ -76,7 +76,10 @@ module ActiveInteractor
       def perform_in_order
         self.class.organized.each do |interface|
           result = execute_interactor_with_callbacks(interface, true)
-          context.merge!(result) if result
+          next if result.nil?
+
+          context.merge!(result)
+          context_fail! if result.failure?
         end
       rescue ActiveInteractor::Error::ContextFailure => e
         context.merge!(e.context)

--- a/lib/active_interactor/organizer/perform.rb
+++ b/lib/active_interactor/organizer/perform.rb
@@ -73,13 +73,17 @@ module ActiveInteractor
         context_fail! if contexts.any?(&:failure?)
       end
 
+      def execute_and_merge_contexts(interface)
+        result = execute_interactor_with_callbacks(interface, true)
+        return if result.nil?
+
+        context.merge!(result)
+        context_fail! if result.failure?
+      end
+
       def perform_in_order
         self.class.organized.each do |interface|
-          result = execute_interactor_with_callbacks(interface, true)
-          next if result.nil?
-
-          context.merge!(result)
-          context_fail! if result.failure?
+          execute_and_merge_contexts(interface)
         end
       rescue ActiveInteractor::Error::ContextFailure => e
         context.merge!(e.context)

--- a/spec/integration/an_organizer_with_failing_nested_organizer_spec.rb
+++ b/spec/integration/an_organizer_with_failing_nested_organizer_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'An organizer with failing nested organizer', type: :integration do
+  let!(:parent_interactor1) { build_interactor('TestParentInteractor1') }
+  let!(:parent_interactor2) { build_interactor('TestParentInteractor2') }
+  let!(:child_interactor1) { build_interactor('TestChildInteractor1') }
+  let!(:child_interactor2) do
+    build_interactor('TestChildInteractor2') do
+      def perform
+        context.fail!
+      end
+    end
+  end
+
+  let!(:child_interactor_class) do
+    build_organizer('TestChildOrganizer') do
+      organize TestChildInteractor1, TestChildInteractor2
+    end
+  end
+
+  let(:parent_interactor_class) do
+    build_organizer('TestParentOrganizer') do
+      organize TestParentInteractor1, TestChildOrganizer, TestParentInteractor2
+    end
+  end
+
+  describe '.perform' do
+    subject { parent_interactor_class.perform }
+
+    before do
+      expect_any_instance_of(child_interactor_class).to receive(:perform).and_call_original
+      expect_any_instance_of(child_interactor1).to receive(:perform).and_call_original
+      expect_any_instance_of(child_interactor2).to receive(:perform).and_call_original
+      expect_any_instance_of(child_interactor2).to receive(:rollback).and_call_original
+      expect_any_instance_of(child_interactor1).to receive(:rollback).and_call_original
+      expect_any_instance_of(parent_interactor1).to receive(:rollback).and_call_original
+      expect_any_instance_of(parent_interactor2).not_to receive(:perform).and_call_original
+      expect_any_instance_of(parent_interactor2).not_to receive(:rollback).and_call_original
+    end
+
+    it { is_expected.to be_a parent_interactor_class.context_class }
+
+    it { is_expected.to be_failure }
+  end
+end

--- a/spec/integration/an_organizer_with_failing_nested_organizer_spec.rb
+++ b/spec/integration/an_organizer_with_failing_nested_organizer_spec.rb
@@ -30,14 +30,14 @@ RSpec.describe 'An organizer with failing nested organizer', type: :integration 
     subject { parent_interactor_class.perform }
 
     before do
-      expect_any_instance_of(child_interactor_class).to receive(:perform).and_call_original
-      expect_any_instance_of(child_interactor1).to receive(:perform).and_call_original
-      expect_any_instance_of(child_interactor2).to receive(:perform).and_call_original
-      expect_any_instance_of(child_interactor2).to receive(:rollback).and_call_original
-      expect_any_instance_of(child_interactor1).to receive(:rollback).and_call_original
-      expect_any_instance_of(parent_interactor1).to receive(:rollback).and_call_original
-      expect_any_instance_of(parent_interactor2).not_to receive(:perform).and_call_original
-      expect_any_instance_of(parent_interactor2).not_to receive(:rollback).and_call_original
+      expect_any_instance_of(child_interactor_class).to receive(:perform).exactly(:once).and_call_original
+      expect_any_instance_of(child_interactor1).to receive(:perform).exactly(:once).and_call_original
+      expect_any_instance_of(child_interactor2).to receive(:perform).exactly(:once).and_call_original
+      expect_any_instance_of(child_interactor2).to receive(:rollback).exactly(:once).and_call_original
+      expect_any_instance_of(child_interactor1).to receive(:rollback).exactly(:once).and_call_original
+      expect_any_instance_of(parent_interactor1).to receive(:rollback).exactly(:once).and_call_original
+      expect_any_instance_of(parent_interactor2).not_to receive(:perform).exactly(:once).and_call_original
+      expect_any_instance_of(parent_interactor2).not_to receive(:rollback).exactly(:once).and_call_original
     end
 
     it { is_expected.to be_a parent_interactor_class.context_class }


### PR DESCRIPTION
## Description

<!-- Summarize the pull request -->
Allow nested Organizers to fail/rollback parent organizer context

## Information

- [ ] Contains Documentation
- [x] Contains Tests
- [ ] Contains Breaking Changes

## Related Issues

<!-- besure to use the github action format for issues -->
<!-- <action> [issue_id] -->
<!-- i.e. "resloves #1" -->
<!-- delete this if there are no related issues -->
- see #243 

## Changelog

<!-- provide any changelog items this pull request implements -->
<!-- follow the keep a changelog format -->
<!-- see https://keepachangelog.com/en/1.0.0/ -->
<!-- delete any unused headings -->

### Added

- Fail context in `ActiveInteractor::Organizer#perform_in_order` after nested failing organizer execution

### Changed

- Extract `ActiveInteractor::Organizer#perform_in_order` logic to `ActiveInteractor::Organizer#execute_and_merge_contexts` to avoid code climate method-complexity offense

### Fixed

- #243 Failing Nested Organizers to fail/rollback parent organizer
