### PR TITLE
Allow undefined optional attributes to be set internally

### DIFF
--- a/lib/active_interactor/context/attributes.rb
+++ b/lib/active_interactor/context/attributes.rb
@@ -117,7 +117,7 @@ module ActiveInteractor
       def merge!(context)
         merge_errors!(context) if context.respond_to?(:errors)
         copy_flags!(context)
-        context.each_pair do |key, value|
+        merged_context_attributes(context).each_pair do |key, value|
           public_send("#{key}=", value) unless value.nil?
         end
         self
@@ -127,6 +127,13 @@ module ActiveInteractor
 
       def _called
         @_called ||= []
+      end
+
+      def merged_context_attributes(context)
+        attrs = {}
+        attrs.merge!(context.to_h) if context.respond_to?(:to_h)
+        attrs.merge!(context.attributes.to_h) if context.respond_to?(:attributes)
+        attrs
       end
 
       def context_attributes_as_hash(context)

--- a/lib/active_interactor/context/attributes.rb
+++ b/lib/active_interactor/context/attributes.rb
@@ -69,6 +69,17 @@ module ActiveInteractor
         @table[name.to_sym] || attributes[name.to_sym]
       end
 
+      # Sets value of a Hash attribute in context.attributes
+      #
+      # @param name [String, Symbol] the key name of the attribute
+      # @param value [*] the value to be given attribute name
+      # @returns [*] the attribute value
+      def []=(name, value)
+        public_send("#{name}=", value)
+
+        super
+      end
+
       # Get values defined on the instance of {Base context} whose keys are defined on the {Base context} class'
       # {ClassMethods#attributes .attributes}
       #
@@ -117,6 +128,7 @@ module ActiveInteractor
       def merge!(context)
         merge_errors!(context) if context.respond_to?(:errors)
         copy_flags!(context)
+
         merged_context_attributes(context).each_pair do |key, value|
           public_send("#{key}=", value) unless value.nil?
         end

--- a/spec/integration/a_basic_organizer_spec.rb
+++ b/spec/integration/a_basic_organizer_spec.rb
@@ -140,6 +140,7 @@ RSpec.describe 'A basic organizer', type: :integration do
     let!(:test_context_class) do
       build_context('TestInteractor1Context') do
         attributes :foo
+        attributes :baz
       end
     end
 
@@ -151,6 +152,9 @@ RSpec.describe 'A basic organizer', type: :integration do
           context.has_foo_as_element = context[:foo].present?
           context.has_bar_as_method = context.bar.present?
           context.has_bar_as_element = context[:bar].present?
+          context.baz = 'baz'
+          context.has_baz_as_method = context.baz.present?
+          context.has_baz_as_element = context[:baz].present?
         end
       end
     end
@@ -167,13 +171,15 @@ RSpec.describe 'A basic organizer', type: :integration do
 
       describe '.perform' do
         subject(:result) { interactor_class.perform(context_attributes) }
-        it { is_expected.to have_attributes(foo: 'foo', bar: 'bar') }
+        it { is_expected.to have_attributes(foo: 'foo', bar: 'bar', baz: 'baz') }
 
         it 'is expected to copy all attributes in the contexts to each interactor' do
           expect(subject.has_foo_as_method).to be true
           expect(subject.has_foo_as_element).to be true
           expect(subject.has_bar_as_method).to be true
           expect(subject.has_bar_as_element).to be true
+          expect(subject.has_baz_as_method).to be true
+          expect(subject.has_baz_as_element).to be true
         end
 
         describe '#attributes' do

--- a/spec/integration/a_basic_organizer_spec.rb
+++ b/spec/integration/a_basic_organizer_spec.rb
@@ -141,6 +141,7 @@ RSpec.describe 'A basic organizer', type: :integration do
       build_context('TestInteractor1Context') do
         attributes :foo
         attributes :baz
+        attributes :zoo
       end
     end
 
@@ -155,6 +156,9 @@ RSpec.describe 'A basic organizer', type: :integration do
           context.baz = 'baz'
           context.has_baz_as_method = context.baz.present?
           context.has_baz_as_element = context[:baz].present?
+          context[:zoo] = 'zoo'
+          context.has_zoo_as_method = context.zoo.present?
+          context.has_zoo_as_element = context[:zoo].present?
         end
       end
     end
@@ -171,7 +175,7 @@ RSpec.describe 'A basic organizer', type: :integration do
 
       describe '.perform' do
         subject(:result) { interactor_class.perform(context_attributes) }
-        it { is_expected.to have_attributes(foo: 'foo', bar: 'bar', baz: 'baz') }
+        it { is_expected.to have_attributes(foo: 'foo', bar: 'bar', baz: 'baz', zoo: 'zoo') }
 
         it 'is expected to copy all attributes in the contexts to each interactor' do
           expect(subject.has_foo_as_method).to be true
@@ -180,6 +184,8 @@ RSpec.describe 'A basic organizer', type: :integration do
           expect(subject.has_bar_as_element).to be true
           expect(subject.has_baz_as_method).to be true
           expect(subject.has_baz_as_element).to be true
+          expect(subject.has_zoo_as_method).to be true
+          expect(subject.has_zoo_as_element).to be true
         end
 
         describe '#attributes' do


### PR DESCRIPTION
## Description

<!-- Summarize the pull request -->
Undefined optional attributes not being updated (on external context) from internal interactors.

## Information

- [x] Contains Documentation
- [x] Contains Tests
- [ ] Contains Breaking Changes

## Related Issues

<!-- besure to use the github action format for issues -->
<!-- <action> [issue_id] -->
<!-- i.e. "resloves #1" -->
<!-- delete this if there are no related issues -->
- https://github.com/aaronmallen/activeinteractor/issues/242

## Changelog

<!-- provide any changelog items this pull request implements -->
<!-- follow the keep a changelog format -->
<!-- see https://keepachangelog.com/en/1.0.0/ -->
<!-- delete any unused headings -->

### Added

- `ActiveInteractor::Context::Attributes#[]=` to set Hash attributes in `ActiveInteractor::Context::Attributes#attributes`

### Changed

- `ActiveInteractor::Context::Attributes#merge!` to use attributes from both `ActiveInteractor::Context::Attributes#attributes` and `ActiveInteractor::Context::Attributes#to_h`

### Fixed

- https://github.com/aaronmallen/activeinteractor/issues/242 Optional attributes are always null
