### PR TITLE
Support in place Callbacks

### DIFF
--- a/lib/active_interactor/organizer/perform.rb
+++ b/lib/active_interactor/organizer/perform.rb
@@ -74,11 +74,13 @@ module ActiveInteractor
       end
 
       def execute_and_merge_contexts(interface)
+        interface.execute_inplace_callback(self, :before)
         result = execute_interactor_with_callbacks(interface, true)
         return if result.nil?
 
         context.merge!(result)
         context_fail! if result.failure?
+        interface.execute_inplace_callback(self, :after)
       end
 
       def perform_in_order

--- a/spec/active_interactor/organizer/interactor_interface_spec.rb
+++ b/spec/active_interactor/organizer/interactor_interface_spec.rb
@@ -84,6 +84,72 @@ RSpec.describe ActiveInteractor::Organizer::InteractorInterface do
         end
       end
 
+      context 'with options {:before => :some_method }' do
+        let(:options) { { before: :some_method } }
+
+        describe '#callbacks' do
+          subject { instance.callbacks }
+
+          it { is_expected.to eq(before: :some_method) }
+        end
+
+        describe '#perform_options' do
+          subject { instance.perform_options }
+
+          it { is_expected.to be_empty }
+        end
+      end
+
+      context 'with options {:before => -> { context.test = true } }' do
+        let(:options) { { before: -> { context.test = true } } }
+
+        describe '#callbacks' do
+          subject { instance.callbacks }
+
+          it { expect(subject[:before]).not_to be_nil }
+          it { expect(subject[:before]).to be_a Proc }
+        end
+
+        describe '#perform_options' do
+          subject { instance.perform_options }
+
+          it { is_expected.to be_empty }
+        end
+      end
+
+      context 'with options {:after => :some_method }' do
+        let(:options) { { after: :some_method } }
+
+        describe '#callbacks' do
+          subject { instance.callbacks }
+
+          it { is_expected.to eq(after: :some_method) }
+        end
+
+        describe '#perform_options' do
+          subject { instance.perform_options }
+
+          it { is_expected.to be_empty }
+        end
+      end
+
+      context 'with options {:after => -> { context.test = true } }' do
+        let(:options) { { after: -> { context.test = true } } }
+
+        describe '#callbacks' do
+          subject { instance.callbacks }
+
+          it { expect(subject[:after]).not_to be_nil }
+          it { expect(subject[:after]).to be_a Proc }
+        end
+
+        describe '#perform_options' do
+          subject { instance.perform_options }
+
+          it { is_expected.to be_empty }
+        end
+      end
+
       context 'with options { :validate => false }' do
         let(:options) { { validate: false } }
 
@@ -100,13 +166,19 @@ RSpec.describe ActiveInteractor::Organizer::InteractorInterface do
         end
       end
 
-      context 'with options { :if => :some_method, :validate => false }' do
-        let(:options) { { if: :some_method, validate: false } }
+      context 'with options { :if => :some_method, :validate => false, :before => :other_method }' do
+        let(:options) { { if: :some_method, validate: false, before: :other_method } }
 
         describe '#filters' do
           subject { instance.filters }
 
           it { is_expected.to eq(if: :some_method) }
+        end
+
+        describe '#callbacks' do
+          subject { instance.callbacks }
+
+          it { is_expected.to eq(before: :other_method) }
         end
 
         describe '#perform_options' do

--- a/spec/integration/an_organizer_with_options_callbacks_spec.rb
+++ b/spec/integration/an_organizer_with_options_callbacks_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'An organizer with options callbacks', type: :integration do
+  let!(:interactor1) do
+    build_interactor('TestInteractor1') do
+      def perform
+        context.step = 3 if context.step == 2
+        context.step = 6 if context.step == 5
+      end
+    end
+  end
+
+  let(:interactor_class) do
+    build_organizer do
+      organize do
+        add TestInteractor1, before: :test_before_method, after: :test_after_method
+        add TestInteractor1, before: lambda {
+          context.step = 5 if context.step == 4
+        }, after: lambda {
+          context.step = 7 if context.step == 6
+        }
+      end
+
+      private
+
+      def test_before_method
+        context.step = 2 if context.step == 1
+      end
+
+      def test_after_method
+        context.step = 4 if context.step == 3
+      end
+    end
+  end
+
+  include_examples 'a class with interactor methods'
+  include_examples 'a class with interactor callback methods'
+  include_examples 'a class with interactor context methods'
+  include_examples 'a class with organizer callback methods'
+
+  describe '.perform' do
+    subject { interactor_class.perform(step: 1) }
+
+    it { is_expected.to be_a interactor_class.context_class }
+    it 'is expected to receive #test_before_method once' do
+      expect_any_instance_of(interactor_class).to receive(:test_before_method)
+        .exactly(:once)
+      subject
+    end
+
+    it 'is expected to receive #test_after_method once' do
+      expect_any_instance_of(interactor_class).to receive(:test_after_method)
+        .exactly(:once)
+      subject
+    end
+
+    it 'runs callbacks in sequence' do
+      expect(subject.step).to eq(7)
+    end
+  end
+end


### PR DESCRIPTION
## Description

<!-- Summarize the pull request -->
Allow developers to add in place callbacks to be able to update context in order to be able to resuse interactors in different contexts. 

## Information

- [ ] Contains Documentation
- [x] Contains Tests
- [ ] Contains Breaking Changes

## Related Issues

<!-- besure to use the github action format for issues -->
<!-- <action> [issue_id] -->
<!-- i.e. "resloves #1" -->
<!-- delete this if there are no related issues -->
- see https://github.com/aaronmallen/activeinteractor/issues/247

## Changelog

<!-- provide any changelog items this pull request implements -->
<!-- follow the keep a changelog format -->
<!-- see https://keepachangelog.com/en/1.0.0/ -->
<!-- delete any unused headings -->

### Added

- `ActiveInteractor::Organizer::InteractorInterface#execute_inplace_callback`

### Changed

- `ActiveInteractor::Organizer#execute_and_merge_contexts`
