### PR TITLE
Allow default attributes to propagate to child/sibling interactors

### DIFF
--- a/lib/active_interactor/context/attributes.rb
+++ b/lib/active_interactor/context/attributes.rb
@@ -170,8 +170,8 @@ module ActiveInteractor
       def merge_attribute_values(context)
         return unless context
 
-        context.each_pair do |key, value|
-          public_send("#{key}=", value)
+        attributes.compact.merge(context).each_pair do |key, value|
+          self[key] = value
         end
       end
     end

--- a/lib/active_interactor/context/attributes.rb
+++ b/lib/active_interactor/context/attributes.rb
@@ -132,7 +132,7 @@ module ActiveInteractor
         copy_flags!(context)
 
         merged_context_attributes(context).each_pair do |key, value|
-          public_send("#{key}=", value) unless value.nil?
+          self[key] = value unless value.nil?
         end
         self
       end

--- a/lib/active_interactor/context/attributes.rb
+++ b/lib/active_interactor/context/attributes.rb
@@ -79,7 +79,7 @@ module ActiveInteractor
       def []=(name, value)
         public_send("#{name}=", value)
 
-        super
+        super unless @table.nil?
       end
 
       # Get values defined on the instance of {Base context} whose keys are defined on the {Base context} class'

--- a/spec/integration/a_basic_organizer_spec.rb
+++ b/spec/integration/a_basic_organizer_spec.rb
@@ -228,8 +228,9 @@ RSpec.describe 'A basic organizer', type: :integration do
     context 'when passing default attributes on the organizer and its interactors' do
       let!(:test_organizer_context_class) do
         build_context('TestOrganizerContext') do
-          attributes :foo
-          attributes :baz
+          attribute :foo
+          attribute :baz
+          attribute :zoo, default: 'zoo'
         end
       end
 
@@ -238,6 +239,7 @@ RSpec.describe 'A basic organizer', type: :integration do
           attribute :foo
           attribute :bar, default: 'bar'
           attribute :baz, default: 'baz'
+          attribute :zoo
         end
       end
 
@@ -254,6 +256,7 @@ RSpec.describe 'A basic organizer', type: :integration do
           def perform
             context.bar = 'bar'
             context.baz_is_set_at_3 = (context.baz == 'baz')
+            context.zoo_is_set_at_3 = (context.zoo == 'zoo')
           end
         end
       end
@@ -262,6 +265,7 @@ RSpec.describe 'A basic organizer', type: :integration do
         build_interactor('TestInteractor4') do
           def perform
             context.baz_is_set_at_4 = (context.baz == 'baz')
+            context.zoo_is_set_at_4 = (context.zoo == 'zoo')
           end
         end
       end
@@ -297,6 +301,12 @@ RSpec.describe 'A basic organizer', type: :integration do
           let(:context_attributes) { {} }
 
           it { is_expected.to have_attributes(baz: 'baz', baz_is_set_at_3: true, baz_is_set_at_4: true) }
+        end
+
+        context 'when [:zoo] is nil' do
+          let(:context_attributes) { {} }
+
+          it { is_expected.to have_attributes(zoo: 'zoo', zoo_is_set_at_3: true, zoo_is_set_at_4: true) }
         end
       end
     end

--- a/spec/integration/a_basic_organizer_spec.rb
+++ b/spec/integration/a_basic_organizer_spec.rb
@@ -231,6 +231,7 @@ RSpec.describe 'A basic organizer', type: :integration do
           attribute :foo
           attribute :baz
           attribute :zoo, default: 'zoo'
+          attribute :taz, default: 'taz0'
         end
       end
 
@@ -240,6 +241,7 @@ RSpec.describe 'A basic organizer', type: :integration do
           attribute :bar, default: 'bar'
           attribute :baz, default: 'baz'
           attribute :zoo
+          attribute :taz, default: 'taz3'
         end
       end
 
@@ -255,6 +257,7 @@ RSpec.describe 'A basic organizer', type: :integration do
         build_interactor('TestInteractor3') do
           def perform
             context.bar = 'bar'
+            context.taz_is_set_at_3 = (context.taz == 'taz')
             context.baz_is_set_at_3 = (context.baz == 'baz')
             context.zoo_is_set_at_3 = (context.zoo == 'zoo')
           end
@@ -264,6 +267,7 @@ RSpec.describe 'A basic organizer', type: :integration do
       let!(:test_interactor_4) do
         build_interactor('TestInteractor4') do
           def perform
+            context.taz_is_set_at_4 = (context.taz == 'taz')
             context.baz_is_set_at_4 = (context.baz == 'baz')
             context.zoo_is_set_at_4 = (context.zoo == 'zoo')
           end
@@ -312,6 +316,12 @@ RSpec.describe 'A basic organizer', type: :integration do
           let(:context_attributes) { { foo: 'foo' } }
 
           it { is_expected.to have_attributes(foo: 'foo', bar: 'bar', baz: 'baz') }
+        end
+
+        context 'when [:taz] is defined' do
+          let(:context_attributes) { { taz: 'taz' } }
+
+          it { is_expected.to have_attributes(taz: 'taz', taz_is_set_at_3: true, taz_is_set_at_4: true) }
         end
 
         context 'when [:bar] is nil' do

--- a/spec/integration/a_basic_organizer_spec.rb
+++ b/spec/integration/a_basic_organizer_spec.rb
@@ -276,6 +276,29 @@ RSpec.describe 'A basic organizer', type: :integration do
         end
       end
 
+      describe '.context_class' do
+        describe 'TestOrganizer' do
+          subject { interactor_class.context_class }
+
+          it { is_expected.to eq TestOrganizerContext }
+          it { is_expected.to be < ActiveInteractor::Context::Base }
+        end
+
+        describe 'TestInteractor3' do
+          subject { test_interactor_3.context_class }
+
+          it { is_expected.to eq TestInteractor3Context }
+          it { is_expected.to be < ActiveInteractor::Context::Base }
+        end
+
+        describe 'TestInteractor4' do
+          subject { test_interactor_4.context_class }
+
+          it { is_expected.to eq TestInteractor4Context }
+          it { is_expected.to be < ActiveInteractor::Context::Base }
+        end
+      end
+
       describe '.perform' do
         subject(:result) { interactor_class.perform(context_attributes) }
 

--- a/spec/integration/a_basic_organizer_spec.rb
+++ b/spec/integration/a_basic_organizer_spec.rb
@@ -224,5 +224,81 @@ RSpec.describe 'A basic organizer', type: :integration do
         end
       end
     end
+
+    context 'when passing default attributes on the organizer and its interactors' do
+      let!(:test_organizer_context_class) do
+        build_context('TestOrganizerContext') do
+          attributes :foo
+          attributes :baz
+        end
+      end
+
+      let!(:test_interactor_3_context_class) do
+        build_context('TestInteractor3Context') do
+          attribute :foo
+          attribute :bar, default: 'bar'
+          attribute :baz, default: 'baz'
+        end
+      end
+
+      let!(:test_interactor_4_context_class) do
+        build_context('TestInteractor4Context') do
+          attribute :foo
+          attribute :bar, default: 'bar'
+          attribute :baz
+        end
+      end
+
+      let!(:test_interactor_3) do
+        build_interactor('TestInteractor3') do
+          def perform
+            context.bar = 'bar'
+            context.baz_is_set_at_3 = (context.baz == 'baz')
+          end
+        end
+      end
+
+      let!(:test_interactor_4) do
+        build_interactor('TestInteractor4') do
+          def perform
+            context.baz_is_set_at_4 = (context.baz == 'baz')
+          end
+        end
+      end
+
+      let!(:interactor_class) do
+        build_organizer('TestOrganizer') do
+          organize TestInteractor3, TestInteractor4
+        end
+      end
+
+      describe '.perform' do
+        subject(:result) { interactor_class.perform(context_attributes) }
+
+        context 'when inputs are not defined' do
+          let(:context_attributes) { {} }
+
+          it { is_expected.to have_attributes(foo: nil, bar: 'bar', baz: 'baz') }
+        end
+
+        context 'when [:foo] is defined' do
+          let(:context_attributes) { { foo: 'foo' } }
+
+          it { is_expected.to have_attributes(foo: 'foo', bar: 'bar', baz: 'baz') }
+        end
+
+        context 'when [:bar] is nil' do
+          let(:context_attributes) { { bar: nil } }
+
+          it { is_expected.to have_attributes(foo: nil, bar: 'bar', baz: 'baz') }
+        end
+
+        context 'when [:baz] is nil' do
+          let(:context_attributes) { {} }
+
+          it { is_expected.to have_attributes(baz: 'baz', baz_is_set_at_3: true, baz_is_set_at_4: true) }
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
## Description

<!-- Summarize the pull request -->
* Add test cases to cover expected behavior for context default attributes.
* Ensure that default attributes are correctly accessible in all interactors pending to perform.

## Information

- [ ] Contains Documentation
- [x] Contains Tests
- [ ] Contains Breaking Changes

## Related Issues

<!-- besure to use the github action format for issues -->
<!-- <action> [issue_id] -->
<!-- i.e. "resloves #1" -->
<!-- delete this if there are no related issues -->
- see https://github.com/aaronmallen/activeinteractor/issues/277.

## Changelog

<!-- provide any changelog items this pull request implements -->
<!-- follow the keep a changelog format -->
<!-- see https://keepachangelog.com/en/1.0.0/ -->
<!-- delete any unused headings -->

### Changed

- `ActiveInteractor::Context::Attributes#merge!` to set attributes in both `ActiveInteractor::Context::Attributes#attributes` and `ActiveInteractor::Context::Attributes#table`
- `ActiveInteractor::Context::Attributes#initialize` to set attributes in both `ActiveInteractor::Context::Attributes#attributes` and `ActiveInteractor::Context::Attributes#table`

### Fixed

- https://github.com/aaronmallen/activeinteractor/issues/277 Allow default attributes to propagate to sibling/child interactors
