### PR TITLE
reintroduce ActiveInteractor::VERSION to ensure backwards compatibility

### DIFF
--- a/lib/active_interactor/version.rb
+++ b/lib/active_interactor/version.rb
@@ -1,17 +1,35 @@
 # frozen_string_literal: true
 
 module ActiveInteractor
+  # The ActiveInteractor version info
+  #
+  # @author Aaron Allen <hello@aaronmallen.me>
+  # @since unreleased
   module Version
+    # The ActiveInterctor major version number
+    # @return [Integer] The ActiveInteractor major version number
     MAJOR = 1
+    # The ActiveInterctor minor version number
+    # @return [Integer] The ActiveInteractor minor version number
     MINOR = 1
+    # The ActiveInterctor patch version number
+    # @return [Integer] The ActiveInteractor patch version number
     PATCH = 0
+    # The ActiveInterctor pre-release version
+    # @return [String | nil] The ActiveInteractor pre-release version
     PRE = nil
+    # The ActiveInterctor meta version
+    # @return [String | nil] The ActiveInteractor meta version
     META = nil
 
+    # The ActiveInterctor rubygems version
+    # @return [String] The ActiveInteractor rubygems version
     def self.gem_version
       @gem_version ||= [MAJOR, MINOR, PATCH, PRE, META].compact.join('.').freeze
     end
 
+    # The ActiveInterctor semver version
+    # @return [String] The ActiveInteractor semver version
     def self.semver
       @semver ||= begin
         primary = [MAJOR, MINOR, PATCH].join('.').freeze
@@ -22,4 +40,8 @@ module ActiveInteractor
       end
     end
   end
+
+  # The ActiveInteractor version
+  # @return [String] the ActiveInteractor version
+  VERSION = Version.semver
 end

--- a/spec/active_interactor_spec.rb
+++ b/spec/active_interactor_spec.rb
@@ -3,6 +3,12 @@
 require 'spec_helper'
 
 RSpec.describe ActiveInteractor do
+  describe '::VERSION' do
+    subject { described_class::VERSION }
+
+    it { is_expected.to be_a String }
+  end
+
   describe '.config' do
     subject { described_class.config }
 


### PR DESCRIPTION
## Description

<!-- Summarize the pull request -->
reintroduce `ActiveInteractor::VERSION` to ensure backwards compatibility

## Information

- [x] Contains Documentation
- [x] Contains Tests
- [ ] Contains Breaking Changes