### PR TITLE
drop bug support for 1.0.x

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,7 +5,7 @@
 | Version | Supported                |
 | ------- | ------------------------ |
 | 1.1.x   | :rocket: :beetle: :lock: |
-| 1.0.x   | :beetle: :lock:          |
+| 1.0.x   | :lock:                   |
 | 0.1.x   | :x:                      |
 
 - :rocket: - Currently addressing feature requests


### PR DESCRIPTION
## Description

<!-- Summarize the pull request -->
Drop bugfix support in `1.0.x` in favor of addressing them in `1.1.x`.  The changes between `1.0` and `1.1` are pretty minimal so asking consumers to update to the next minor isn't unreasonable.
