### PR TITLE
#217 interactor failure hooks

### DIFF
--- a/lib/active_interactor/interactor/callbacks.rb
+++ b/lib/active_interactor/interactor/callbacks.rb
@@ -193,6 +193,31 @@ module ActiveInteractor
           set_callback(:validation, :before, *args, options, &block)
         end
 
+        # Define a callback to call before an {Base interactor} fails
+        #
+        # @since unreleased
+        #
+        # @example
+        #   class MyInteractor < ActiveInteractor::Base
+        #     before_failure :log_error
+        #
+        #     def perform
+        #       context.fail!("I failed!")
+        #     end
+        #
+        #     private
+        #
+        #     def log_error
+        #       p context.errors.full_messages
+        #     end
+        #   end
+        #
+        #   result = MyInteractor.perform
+        #   #=> ["Context I failed!"]
+        def before_failure(*filters, &block)
+          set_callback(:failure, :before, *filters, &block)
+        end
+
         # Define a callback to call before {Interactor::Perform#perform #perform} has been called on an
         # {Base interactor} instance
         #
@@ -267,7 +292,7 @@ module ActiveInteractor
           define_callbacks :validation,
                            skip_after_callbacks_if_terminated: true,
                            scope: %i[kind name]
-          define_callbacks :perform, :rollback
+          define_callbacks :failure, :perform, :rollback
         end
       end
     end

--- a/lib/active_interactor/interactor/worker.rb
+++ b/lib/active_interactor/interactor/worker.rb
@@ -88,8 +88,8 @@ module ActiveInteractor
 
       def handle_error(exception)
         @context = interactor.finalize_context!
-        execute_rollback
         interactor.run_callbacks :failure
+        execute_rollback
         ActiveSupport::Notifications.instrument('interactor failure') { raise exception }
       end
 

--- a/lib/active_interactor/interactor/worker.rb
+++ b/lib/active_interactor/interactor/worker.rb
@@ -89,7 +89,8 @@ module ActiveInteractor
       def handle_error(exception)
         @context = interactor.finalize_context!
         execute_rollback
-        raise exception
+        interactor.run_callbacks :failure
+        ActiveSupport::Notifications.instrument('interactor failure') { raise exception }
       end
 
       def validate_context(validation_context = nil)

--- a/spec/support/shared_examples/a_class_with_interactor_callback_methods_example.rb
+++ b/spec/support/shared_examples/a_class_with_interactor_callback_methods_example.rb
@@ -73,6 +73,18 @@ RSpec.shared_examples 'a class with interactor callback methods' do
     end
   end
 
+  describe '.before_failure' do
+    subject { interactor_class.before_failure(*args) }
+    let(:args) { :some_method }
+
+    it 'is expected to receive #set_callback with :failure, :before, :some_method' do
+      expect(interactor_class).to receive(:set_callback)
+        .with(:failure, :before, :some_method)
+        .and_return(true)
+      subject
+    end
+  end
+
   describe '.before_perform' do
     subject { interactor_class.before_perform(*args) }
     let(:args) { :some_method }


### PR DESCRIPTION
## Description

<!-- Summarize the pull request -->
Provide a way to hook into interactor failures.

## Information

- [x] Contains Documentation
- [x] Contains Tests
- [ ] Contains Breaking Changes

## Related Issues

<!-- besure to use the github action format for issues -->
<!-- <action> [issue_id] -->
<!-- i.e. "resloves #1" -->
<!-- delete this if there are no related issues -->
- see #217 

## Changelog

<!-- provide any changelog items this pull request implements -->
<!-- follow the keep a changelog format -->
<!-- see https://keepachangelog.com/en/1.0.0/ -->
<!-- delete any unused headings -->

### Added

- `ActiveInteractor::Base.before_failure`

### Changed

- Interactors will now emit an `ActiveSupport::Notification` named `interactor failure` on interactor failure.
