### PR TITLE
#270 ensure interactor returns a ActiveInteractor::Interactor::Result

### DIFF
--- a/lib/active_interactor/context/attributes.rb
+++ b/lib/active_interactor/context/attributes.rb
@@ -50,13 +50,14 @@ module ActiveInteractor
       # @param context [Hash, Base, Class] attributes to assign to the {Base context}
       # @return [Base] a new instance of {Base}
       def initialize(context = {})
-        merge_errors!(context) if context.respond_to?(:errors)
-        copy_flags!(context)
-        copy_called!(context)
-        context = context_attributes_as_hash(context) || {}
+        context_object = context.is_a?(ActiveInteractor::Interactor::Result) ? context.context : context
+        merge_errors!(context_object) if context_object.respond_to?(:errors)
+        copy_flags!(context_object)
+        copy_called!(context_object)
+        context_object = context_attributes_as_hash(context_object) || {}
         super
 
-        merge_attribute_values(context)
+        merge_attribute_values(context_object)
       end
 
       # Returns the value of an attribute
@@ -128,10 +129,11 @@ module ActiveInteractor
       # @param context [Class] a {Base context} instance to be merged
       # @return [self] the {Base context} instance
       def merge!(context)
-        merge_errors!(context) if context.respond_to?(:errors)
-        copy_flags!(context)
+        context_object = context.is_a?(ActiveInteractor::Interactor::Result) ? context.context : context
+        merge_errors!(context_object) if context_object.respond_to?(:errors)
+        copy_flags!(context_object)
 
-        merged_context_attributes(context).each_pair do |key, value|
+        merged_context_attributes(context_object).each_pair do |key, value|
           self[key] = value unless value.nil?
         end
         self

--- a/lib/active_interactor/interactor/context.rb
+++ b/lib/active_interactor/interactor/context.rb
@@ -232,8 +232,8 @@ module ActiveInteractor
       #  @since 1.0.1
       #
       # @!method context_fail!(errors = nil)
-      #  Call {ActiveInteractor::Context::Status#fail! #fail!} on the {Base interactor} instance's
-      #  {ActiveInteractor::Context::Base context} instance
+      #  Call {ActiveInteractor::Interactor::Result#fail! #fail!} on the {Base interactor} instance's
+      #  {ActiveInteractor::Interactor::Result result} instance
       #
       #  @since 1.0.0
       #
@@ -244,8 +244,8 @@ module ActiveInteractor
       #  @since 1.0.1
       #
       # @!method context_rollback!
-      #  Call {ActiveInteractor::Context::Status#rollback! #rollback!} on the {Base interactor} instance's
-      #  {ActiveInteractor::Context::Base context} instance
+      #  Call {ActiveInteractor::Interactor::Result#rollback! #rollback!} on the {Base interactor} instance's
+      #  {ActiveInteractor::Interactor::Result result} instance
       #
       #  @since 1.0.0
       delegate :attribute_missing, :attribute_names, :fail!, :respond_to_without_attributes?, :rollback!,
@@ -354,19 +354,19 @@ module ActiveInteractor
       # @param context [Hash, Class] attributes to assign to the {Base interactor} instance's
       #  {ActiveInteractor::Context::Base context} instance
       # @return [Base] a new instance of {Base}
-      def initialize(context = {})
-        @context = self.class.context_class.new(context)
+      def initialize(context = {}, state = nil)
+        context_object = self.class.context_class.new(context)
+        @context = Result.new(context_object, state)
       end
 
-      # Mark the {Base interactor} instance as called on the instance's {ActiveInteractor::Context::Base context}
-      # instance and return the {ActiveInteractor::Context::Base context} instance.
+      # Mark the {Base interactor} instance as called on the instance's {ActiveInteractor::Interactor::Result result}
+      # instance and return the {ActiveInteractor::Interactor::Result result} instance.
       #
       # @since 1.0.0
       #
-      # @return [Class] the {ActiveInteractor::Context::Base context} instance
+      # @return [Class] the {ActiveInteractor::Interactor::Result result} instance
       def finalize_context!
-        context.called!(self)
-        context.resolve
+        context.state.called!(self)
         context
       end
 

--- a/lib/active_interactor/interactor/perform.rb
+++ b/lib/active_interactor/interactor/perform.rb
@@ -35,8 +35,8 @@ module ActiveInteractor
         # @param options [Hash, Perform::Options] options to use for the {.perform}. See {Perform::Options}
         # @return [Class] an instance of the {Base interactor} class' {ActiveInteractor::Context::Base context}
         #  instance
-        def perform(context = {}, options = {})
-          new(context).with_options(options).execute_perform
+        def perform(context = {}, options = {}, state = nil)
+          new(context, state).with_options(options).execute_perform
         end
 
         # Initialize a new {Base interactor} instance and call its {Interactor::Perform#perform #perform} method without
@@ -72,8 +72,8 @@ module ActiveInteractor
         #  fails.
         # @return [Class] an instance of the {Base interactor} class' {ActiveInteractor::Context::Base context}
         #  instance
-        def perform!(context = {}, options = {})
-          new(context).with_options(options).execute_perform!
+        def perform!(context = {}, options = {}, state = nil)
+          new(context, state).with_options(options).execute_perform!
         end
       end
 

--- a/lib/active_interactor/interactor/result.rb
+++ b/lib/active_interactor/interactor/result.rb
@@ -61,7 +61,7 @@ module ActiveInteractor
         handle_errors(errors)
         resolve_errors!
         state.fail!
-        raise ActiveInteractor::Error::ContextFailure, context
+        raise ActiveInteractor::Error::ContextFailure, self
       end
 
       # Rollback {ActiveInteractor::Base interactors}. Any {ActiveInteractor::Base interactors} listed in {#state}
@@ -102,12 +102,13 @@ module ActiveInteractor
       end
 
       def method_missing(method_name, *args, &block)
-        context.public_send(method_name, *args, &block)
+        result = context.public_send(method_name, *args, &block)
         ActiveInteractor::Deprecation::V2.deprecation_warning(
           method_name,
           'calling #context methods on an ActiveInteractor::Interactor::Result is deprecated use #context instead',
           caller
         )
+        result
       rescue NoMethodError
         super
       end

--- a/lib/active_interactor/models.rb
+++ b/lib/active_interactor/models.rb
@@ -41,7 +41,6 @@ module ActiveInteractor
 
         include ActiveInteractor::Context::Attributes
         include ActiveInteractor::Context::Errors
-        include ActiveInteractor::Context::Status
         include ActiveInteractor::Models::InstanceMethods
         delegate :each_pair, to: :attributes
       end

--- a/lib/active_interactor/organizer/interactor_interface.rb
+++ b/lib/active_interactor/organizer/interactor_interface.rb
@@ -65,13 +65,13 @@ module ActiveInteractor
       # @raise [Error::ContextFailure] if `fail_on_error` is `true` and the {#interactor_class}
       #  {Context::Status#fail! fails} its {Context::Base context}.
       # @return [Class] an instance of {Context::Base context}
-      def perform(target, context, fail_on_error = false, perform_options = {})
+      def perform(target, context, fail_on_error = false, perform_options = {}, state = nil)
         return if check_conditionals(target, :if) == false
         return if check_conditionals(target, :unless) == true
 
         method = fail_on_error ? :perform! : :perform
         options = self.perform_options.merge(perform_options)
-        interactor_class.send(method, context, options)
+        interactor_class.send(method, context, options, state)
       end
 
       def execute_inplace_callback(target, callback)

--- a/lib/active_interactor/organizer/perform.rb
+++ b/lib/active_interactor/organizer/perform.rb
@@ -56,7 +56,7 @@ module ActiveInteractor
       private
 
       def execute_interactor(interface, fail_on_error = false, perform_options = {})
-        interface.perform(self, context, fail_on_error, perform_options)
+        interface.perform(self, context, fail_on_error, perform_options, @context.state)
       end
 
       def execute_interactor_with_callbacks(interface, fail_on_error = false, perform_options = {})
@@ -68,9 +68,9 @@ module ActiveInteractor
         end
       end
 
-      def merge_contexts(contexts)
-        contexts.each { |context| @context.merge!(context) }
-        context_fail! if contexts.any?(&:failure?)
+      def merge_contexts(results)
+        results.each { |result| @context.merge!(result) }
+        context_fail! if results.any?(&:failure?)
       end
 
       def execute_and_merge_contexts(interface)
@@ -89,6 +89,7 @@ module ActiveInteractor
         end
       rescue ActiveInteractor::Error::ContextFailure => e
         context.merge!(e.context)
+        context_fail!
       end
 
       def perform_in_parallel

--- a/spec/active_interactor/interactor/worker_spec.rb
+++ b/spec/active_interactor/interactor/worker_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe ActiveInteractor::Interactor::Worker do
     describe '#execute_perform' do
       subject { described_class.new(interactor).execute_perform }
 
-      it { is_expected.to be_an TestInteractor.context_class }
+      it { is_expected.to be_an ActiveInteractor::Interactor::Result }
 
       context 'when context fails' do
         before do
@@ -85,7 +85,7 @@ RSpec.describe ActiveInteractor::Interactor::Worker do
         end
 
         it { expect { subject }.not_to raise_error }
-        it { is_expected.to be_an TestInteractor.context_class }
+        it { is_expected.to be_an ActiveInteractor::Interactor::Result }
       end
 
       include_examples 'an interactor with options'
@@ -94,7 +94,7 @@ RSpec.describe ActiveInteractor::Interactor::Worker do
     describe '#execute_perform!' do
       subject { described_class.new(interactor).execute_perform! }
 
-      it { is_expected.to be_an TestInteractor.context_class }
+      it { is_expected.to be_an ActiveInteractor::Interactor::Result }
 
       it 'is expected to run perform callbacks on interactor' do
         expect_any_instance_of(TestInteractor).to receive(:run_callbacks)

--- a/spec/active_interactor/organizer/base_spec.rb
+++ b/spec/active_interactor/organizer/base_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe ActiveInteractor::Organizer::Base do
         end
       end
 
-      it { is_expected.to be_a interactor_class.context_class }
+      it { is_expected.to be_a ActiveInteractor::Interactor::Result }
       it 'is expected to receive #perform on both interactors' do
         expect_any_instance_of(interactor1).to receive(:perform)
         expect_any_instance_of(interactor2).to receive(:perform)
@@ -127,7 +127,7 @@ RSpec.describe ActiveInteractor::Organizer::Base do
       context 'with options :skip_each_perform_callbacks eq to true' do
         subject { interactor_class.perform({}, skip_each_perform_callbacks: true) }
 
-        it { is_expected.to be_a interactor_class.context_class }
+        it { is_expected.to be_a ActiveInteractor::Interactor::Result }
         it 'is expected to receive #perform on both interactors' do
           expect_any_instance_of(interactor1).to receive(:perform)
           expect_any_instance_of(interactor2).to receive(:perform)
@@ -151,7 +151,7 @@ RSpec.describe ActiveInteractor::Organizer::Base do
 
         it { expect { subject }.not_to raise_error }
         it { is_expected.to be_failure }
-        it { is_expected.to be_a interactor_class.context_class }
+        it { is_expected.to be_a ActiveInteractor::Interactor::Result }
         it 'is expected to receive #perform on the first interactor' do
           expect_any_instance_of(interactor1).to receive(:perform)
           subject
@@ -177,7 +177,7 @@ RSpec.describe ActiveInteractor::Organizer::Base do
 
         it { expect { subject }.not_to raise_error }
         it { is_expected.to be_failure }
-        it { is_expected.to be_a interactor_class.context_class }
+        it { is_expected.to be_a ActiveInteractor::Interactor::Result }
         it 'is expected to receive #perform on both interactors' do
           expect_any_instance_of(interactor1).to receive(:perform)
           expect_any_instance_of(interactor2).to receive(:perform)
@@ -199,7 +199,7 @@ RSpec.describe ActiveInteractor::Organizer::Base do
           end
         end
 
-        it { is_expected.to be_a interactor_class.context_class }
+        it { is_expected.to be_a ActiveInteractor::Interactor::Result }
         it 'is expected to receive #perform on both interactors' do
           expect_any_instance_of(interactor1).to receive(:perform)
           expect_any_instance_of(interactor2).to receive(:perform)
@@ -217,7 +217,7 @@ RSpec.describe ActiveInteractor::Organizer::Base do
 
           it { expect { subject }.not_to raise_error }
           it { is_expected.to be_failure }
-          it { is_expected.to be_a interactor_class.context_class }
+          it { is_expected.to be_a ActiveInteractor::Interactor::Result }
           it 'is expected to receive #perform on both interactors' do
             expect_any_instance_of(interactor1).to receive(:perform)
             expect_any_instance_of(interactor2).to receive(:perform)
@@ -241,7 +241,7 @@ RSpec.describe ActiveInteractor::Organizer::Base do
 
           it { expect { subject }.not_to raise_error }
           it { is_expected.to be_failure }
-          it { is_expected.to be_a interactor_class.context_class }
+          it { is_expected.to be_a ActiveInteractor::Interactor::Result }
           it 'is expected to receive #perform on both interactors' do
             expect_any_instance_of(interactor1).to receive(:perform)
             expect_any_instance_of(interactor2).to receive(:perform)

--- a/spec/integration/a_basic_interactor_spec.rb
+++ b/spec/integration/a_basic_interactor_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe 'A basic interactor', type: :integration do
   describe '.perform' do
     subject { interactor_class.perform }
 
-    it { is_expected.to be_a interactor_class.context_class }
+    it { is_expected.to be_a ActiveInteractor::Interactor::Result }
     it { is_expected.to be_successful }
     it { is_expected.to have_attributes(test_field: 'test') }
   end
@@ -34,7 +34,7 @@ RSpec.describe 'A basic interactor', type: :integration do
     subject { interactor_class.perform! }
 
     it { expect { subject }.not_to raise_error }
-    it { is_expected.to be_a interactor_class.context_class }
+    it { is_expected.to be_a ActiveInteractor::Interactor::Result }
     it { is_expected.to be_successful }
     it { is_expected.to have_attributes(test_field: 'test') }
   end
@@ -58,7 +58,7 @@ RSpec.describe 'A basic interactor', type: :integration do
     describe '.perform' do
       subject(:result) { interactor_class.perform }
 
-      it { is_expected.to be_a interactor_class.context_class }
+      it { is_expected.to be_a ActiveInteractor::Interactor::Result }
       it { is_expected.to be_successful }
       it { is_expected.to have_attributes(test_field: 'test', some_other_field: 'test 2') }
 

--- a/spec/integration/a_basic_organizer_spec.rb
+++ b/spec/integration/a_basic_organizer_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe 'A basic organizer', type: :integration do
   describe '.perform' do
     subject { interactor_class.perform }
 
-    it { is_expected.to be_a interactor_class.context_class }
+    it { is_expected.to be_a ActiveInteractor::Interactor::Result }
     it { is_expected.to be_successful }
     it { is_expected.to have_attributes(test_field_1: 'test 1', test_field_2: 'test 2') }
   end
@@ -58,7 +58,7 @@ RSpec.describe 'A basic organizer', type: :integration do
       subject { interactor_class.perform }
 
       it { expect { subject }.not_to raise_error }
-      it { is_expected.to be_a interactor_class.context_class }
+      it { is_expected.to be_a ActiveInteractor::Interactor::Result }
       it { is_expected.to be_failure }
       it 'is expected to receive #rollback on the first interactor' do
         expect_any_instance_of(test_interactor_1).to receive(:rollback)
@@ -81,7 +81,7 @@ RSpec.describe 'A basic organizer', type: :integration do
         end
 
         it { expect { subject }.not_to raise_error }
-        it { is_expected.to be_a interactor_class.context_class }
+        it { is_expected.to be_a ActiveInteractor::Interactor::Result }
         it { is_expected.to be_failure }
         it { expect(subject.errors.count).to eq 1 }
         it 'is expected to have errors "something went wrong" on :context' do
@@ -105,7 +105,7 @@ RSpec.describe 'A basic organizer', type: :integration do
       subject { interactor_class.perform }
 
       it { expect { subject }.not_to raise_error }
-      it { is_expected.to be_a interactor_class.context_class }
+      it { is_expected.to be_a ActiveInteractor::Interactor::Result }
       it { is_expected.to be_failure }
       it 'is expected to receive #rollback on all interactors' do
         expect_any_instance_of(test_interactor_2).to receive(:rollback)
@@ -124,7 +124,7 @@ RSpec.describe 'A basic organizer', type: :integration do
         end
 
         it { expect { subject }.not_to raise_error }
-        it { is_expected.to be_a interactor_class.context_class }
+        it { is_expected.to be_a ActiveInteractor::Interactor::Result }
         it { is_expected.to be_failure }
         it { expect(subject.errors.count).to eq 1 }
         it 'is expected to have errors "something went wrong" on :context' do

--- a/spec/integration/a_failing_interactor_spec.rb
+++ b/spec/integration/a_failing_interactor_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe 'A failing interactor', type: :integration do
     subject { interactor_class.perform }
 
     it { expect { subject }.not_to raise_error }
-    it { is_expected.to be_a interactor_class.context_class }
+    it { is_expected.to be_a ActiveInteractor::Interactor::Result }
     it { is_expected.to be_failure }
     it 'is expected to receive #rollback' do
       expect_any_instance_of(interactor_class).to receive(:rollback)

--- a/spec/integration/an_interactor_with_after_context_validation_callbacks_spec.rb
+++ b/spec/integration/an_interactor_with_after_context_validation_callbacks_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe 'An interactor with .after_context_validation callbacks', type: :
     context 'with valid context attributes' do
       let(:context_attributes) { { test_field: 'TEST' } }
 
-      it { is_expected.to be_a interactor_class.context_class }
+      it { is_expected.to be_a ActiveInteractor::Interactor::Result }
       it { is_expected.to be_successful }
       it { is_expected.to have_attributes(test_field: 'test') }
     end
@@ -52,7 +52,7 @@ RSpec.describe 'An interactor with .after_context_validation callbacks', type: :
       context 'with :test_field "TEST" and :should_downcase true' do
         let(:context_attributes) { { test_field: 'TEST', should_downcase: true } }
 
-        it { is_expected.to be_a interactor_class.context_class }
+        it { is_expected.to be_a ActiveInteractor::Interactor::Result }
         it { is_expected.to be_successful }
         it { is_expected.to have_attributes(test_field: 'test') }
       end
@@ -60,7 +60,7 @@ RSpec.describe 'An interactor with .after_context_validation callbacks', type: :
       context 'with :test_field "TEST" and :should_downcase false' do
         let(:context_attributes) { { test_field: 'TEST', should_downcase: false } }
 
-        it { is_expected.to be_a interactor_class.context_class }
+        it { is_expected.to be_a ActiveInteractor::Interactor::Result }
         it { is_expected.to be_successful }
         it { is_expected.to have_attributes(test_field: 'TEST') }
       end

--- a/spec/integration/an_interactor_with_after_perform_callbacks_spec.rb
+++ b/spec/integration/an_interactor_with_after_perform_callbacks_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe 'An interactor with .after_perform callbacks', type: :integration
   describe '.perform' do
     subject { interactor_class.perform }
 
-    it { is_expected.to be_a interactor_class.context_class }
+    it { is_expected.to be_a ActiveInteractor::Interactor::Result }
     it { is_expected.to be_successful }
     it 'is expected to receive #test_after_perform' do
       expect_any_instance_of(interactor_class).to receive(:test_after_perform)

--- a/spec/integration/an_interactor_with_after_rollback_callbacks_spec.rb
+++ b/spec/integration/an_interactor_with_after_rollback_callbacks_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe 'An interactor with .after_rollback callbacks', type: :integratio
   describe '.perform' do
     subject { interactor_class.perform }
 
-    it { is_expected.to be_a interactor_class.context_class }
+    it { is_expected.to be_a ActiveInteractor::Interactor::Result }
     it 'is expected to receive #test_after_rollback' do
       expect_any_instance_of(interactor_class).to receive(:test_after_rollback)
       subject

--- a/spec/integration/an_interactor_with_an_existing_context_class_spec.rb
+++ b/spec/integration/an_interactor_with_an_existing_context_class_spec.rb
@@ -30,14 +30,14 @@ RSpec.describe 'An interactor with an existing .context_class', type: :integrati
         context 'with valid context attributes' do
           let(:context_attributes) { { test_field: 'test' } }
 
-          it { is_expected.to be_an AnInteractorContext }
+          it { is_expected.to be_an ActiveInteractor::Interactor::Result }
           it { is_expected.to be_successful }
         end
 
         context 'with invalid context attributes' do
           let(:context_attributes) { {} }
 
-          it { is_expected.to be_an AnInteractorContext }
+          it { is_expected.to be_an ActiveInteractor::Interactor::Result }
           it { is_expected.to be_failure }
           it 'is expected to have errors on :some_field' do
             expect(subject.errors[:test_field]).not_to be_nil

--- a/spec/integration/an_interactor_with_around_perform_callbacks_spec.rb
+++ b/spec/integration/an_interactor_with_around_perform_callbacks_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe 'An interactor with .around_perform callbacks', type: :integratio
   describe '.perform' do
     subject { interactor_class.perform }
 
-    it { is_expected.to be_a interactor_class.context_class }
+    it { is_expected.to be_a ActiveInteractor::Interactor::Result }
     it { is_expected.to have_attributes(perform_step: [1, 2, 3]) }
   end
 end

--- a/spec/integration/an_interactor_with_around_rollback_callbacks_spec.rb
+++ b/spec/integration/an_interactor_with_around_rollback_callbacks_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe 'An interactor with .around_rollback callbacks', type: :integrati
   describe '.perform' do
     subject { interactor_class.perform }
 
-    it { is_expected.to be_a interactor_class.context_class }
+    it { is_expected.to be_a ActiveInteractor::Interactor::Result }
     it { is_expected.to have_attributes(rollback_step: [1, 2, 3]) }
   end
 end

--- a/spec/integration/an_interactor_with_before_perform_callbacks_spec.rb
+++ b/spec/integration/an_interactor_with_before_perform_callbacks_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe 'An interactor with .before_perform callbacks', type: :integratio
   describe '.perform' do
     subject { interactor_class.perform }
 
-    it { is_expected.to be_a interactor_class.context_class }
+    it { is_expected.to be_a ActiveInteractor::Interactor::Result }
     it { is_expected.to be_successful }
     it 'is expected to receive #test_before_perform' do
       expect_any_instance_of(interactor_class).to receive(:test_before_perform)

--- a/spec/integration/an_interactor_with_before_rollback_callbacks_spec.rb
+++ b/spec/integration/an_interactor_with_before_rollback_callbacks_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe 'An interactor with .before_rollback callbacks', type: :integrati
   describe '.perform' do
     subject { interactor_class.perform }
 
-    it { is_expected.to be_a interactor_class.context_class }
+    it { is_expected.to be_a ActiveInteractor::Interactor::Result }
     it 'is expected to receive #test_before_rollback' do
       expect_any_instance_of(interactor_class).to receive(:test_before_rollback)
       subject

--- a/spec/integration/an_interactor_with_validations_on_called_spec.rb
+++ b/spec/integration/an_interactor_with_validations_on_called_spec.rb
@@ -23,14 +23,14 @@ RSpec.describe 'An interactor with validations on :called', type: :integration d
     context 'with :should_have_test_field true' do
       let(:context_attributes) { { should_have_test_field: true } }
 
-      it { is_expected.to be_an TestInteractor::Context }
+      it { is_expected.to be_an ActiveInteractor::Interactor::Result }
       it { is_expected.to be_successful }
     end
 
     context 'with :should_have_test_field false' do
       let(:context_attributes) { { should_have_test_field: false } }
 
-      it { is_expected.to be_an TestInteractor::Context }
+      it { is_expected.to be_an ActiveInteractor::Interactor::Result }
       it { is_expected.to be_failure }
       it 'is expected to have errors on :some_field' do
         expect(subject.errors[:test_field]).not_to be_nil

--- a/spec/integration/an_interactor_with_validations_on_calling_spec.rb
+++ b/spec/integration/an_interactor_with_validations_on_calling_spec.rb
@@ -19,14 +19,14 @@ RSpec.describe 'An interactor with validations on :calling', type: :integration 
     context 'with :test_field "test"' do
       let(:context_attributes) { { test_field: 'test' } }
 
-      it { is_expected.to be_an TestInteractor::Context }
+      it { is_expected.to be_an ActiveInteractor::Interactor::Result }
       it { is_expected.to be_successful }
     end
 
     context 'with :test_field nil' do
       let(:context_attributes) { {} }
 
-      it { is_expected.to be_an TestInteractor::Context }
+      it { is_expected.to be_an ActiveInteractor::Interactor::Result }
       it { is_expected.to be_failure }
       it 'is expected to have errors on :some_field' do
         expect(subject.errors[:test_field]).not_to be_nil

--- a/spec/integration/an_interactor_with_validations_spec.rb
+++ b/spec/integration/an_interactor_with_validations_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe 'An interactor with validations', type: :integration do
     context 'with valid context attributes' do
       let(:context_attributes) { { test_field: 'test' } }
 
-      it { is_expected.to be_a interactor_class.context_class }
+      it { is_expected.to be_a ActiveInteractor::Interactor::Result }
       it { is_expected.to be_successful }
       it { is_expected.to have_attributes(test_field: 'test', other_field: 'test') }
     end
@@ -35,7 +35,7 @@ RSpec.describe 'An interactor with validations', type: :integration do
     context 'with invalid context attributes' do
       let(:context_attributes) { {} }
 
-      it { is_expected.to be_a interactor_class.context_class }
+      it { is_expected.to be_a ActiveInteractor::Interactor::Result }
       it { is_expected.to be_failure }
       it { is_expected.to have_attributes(other_field: 'failed') }
       it 'is expected to have errors on :test_field' do
@@ -65,7 +65,7 @@ RSpec.describe 'An interactor with validations', type: :integration do
       context 'with :test_field defined and :test_condition false' do
         let(:context_attributes) { { test_field: 'test', test_condition: false } }
 
-        it { is_expected.to be_a interactor_class.context_class }
+        it { is_expected.to be_a ActiveInteractor::Interactor::Result }
         it { is_expected.to be_successful }
         it { is_expected.to have_attributes(test_field: 'test', test_condition: false, other_field: 'test') }
       end
@@ -73,7 +73,7 @@ RSpec.describe 'An interactor with validations', type: :integration do
       context 'with :test_field defined and :test_condition true' do
         let(:context_attributes) { { test_field: 'test', test_condition: true } }
 
-        it { is_expected.to be_a interactor_class.context_class }
+        it { is_expected.to be_a ActiveInteractor::Interactor::Result }
         it { is_expected.to be_successful }
         it { is_expected.to have_attributes(test_field: 'test', test_condition: true, other_field: 'test') }
       end
@@ -81,7 +81,7 @@ RSpec.describe 'An interactor with validations', type: :integration do
       context 'with :test_field undefined and :test_condition true' do
         let(:context_attributes) { { test_condition: true } }
 
-        it { is_expected.to be_a interactor_class.context_class }
+        it { is_expected.to be_a ActiveInteractor::Interactor::Result }
         it { is_expected.to be_failure }
         it { is_expected.to have_attributes(test_condition: true, other_field: 'failed') }
         it 'is expected to have errors on :test_field' do

--- a/spec/integration/an_organizer_performing_in_parallel_spec.rb
+++ b/spec/integration/an_organizer_performing_in_parallel_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe 'An organizer performing in parallel', type: :integration do
   describe '.perform' do
     subject { interactor_class.perform }
 
-    it { is_expected.to be_a interactor_class.context_class }
+    it { is_expected.to be_a ActiveInteractor::Interactor::Result }
     it { is_expected.to be_successful }
     it { is_expected.to have_attributes(test_field_1: 'test 1', test_field_2: 'test 2') }
   end

--- a/spec/integration/an_organizer_with_after_each_callbacks_spec.rb
+++ b/spec/integration/an_organizer_with_after_each_callbacks_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe 'An organizer with .after_each callbacks', type: :integration do
   describe '.perform' do
     subject { interactor_class.perform }
 
-    it { is_expected.to be_a interactor_class.context_class }
+    it { is_expected.to be_a ActiveInteractor::Interactor::Result }
     it 'is expected to receive #test_after_each_perform twice' do
       expect_any_instance_of(interactor_class).to receive(:test_after_each_perform)
         .exactly(:twice)

--- a/spec/integration/an_organizer_with_around_each_callbacks_spec.rb
+++ b/spec/integration/an_organizer_with_around_each_callbacks_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe 'An organizer with .around_each callbacks', type: :integration do
   describe '.perform' do
     subject { interactor_class.perform }
 
-    it { is_expected.to be_a interactor_class.context_class }
+    it { is_expected.to be_a ActiveInteractor::Interactor::Result }
     it { is_expected.to have_attributes(around_each_step: [1, 2, 3, 4]) }
   end
 end

--- a/spec/integration/an_organizer_with_before_each_callbacks_spec.rb
+++ b/spec/integration/an_organizer_with_before_each_callbacks_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe 'An organizer with .before_each callbacks', type: :integration do
   describe '.perform' do
     subject { interactor_class.perform }
 
-    it { is_expected.to be_a interactor_class.context_class }
+    it { is_expected.to be_a ActiveInteractor::Interactor::Result }
     it 'is expected to receive #test_before_each_perform twice' do
       expect_any_instance_of(interactor_class).to receive(:test_before_each_perform)
         .exactly(:twice)

--- a/spec/integration/an_organizer_with_conditionally_organized_interactors_spec.rb
+++ b/spec/integration/an_organizer_with_conditionally_organized_interactors_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe 'An organizer with conditionally organized interactors', type: :i
       context 'with context_attributes test_1 and test_2 both eq to true' do
         let(:context_attributes) { { test_1: true, test_2: true } }
 
-        it { is_expected.to be_a interactor_class.context_class }
+        it { is_expected.to be_a ActiveInteractor::Interactor::Result }
         it { is_expected.to be_successful }
         it 'is expected to receive #perform on both interactors' do
           expect_any_instance_of(test_interactor_1).to receive(:perform)
@@ -40,7 +40,7 @@ RSpec.describe 'An organizer with conditionally organized interactors', type: :i
       context 'with context_attributes test_1 eq to true and test_2 eq to false' do
         let(:context_attributes) { { test_1: true, test_2: false } }
 
-        it { is_expected.to be_a interactor_class.context_class }
+        it { is_expected.to be_a ActiveInteractor::Interactor::Result }
         it { is_expected.to be_successful }
         it 'is expected to receive #perform on the first interactor' do
           expect_any_instance_of(test_interactor_1).to receive(:perform)
@@ -56,7 +56,7 @@ RSpec.describe 'An organizer with conditionally organized interactors', type: :i
       context 'with context_attributes test_1 eq to false and test_2 eq to true' do
         let(:context_attributes) { { test_1: false, test_2: true } }
 
-        it { is_expected.to be_a interactor_class.context_class }
+        it { is_expected.to be_a ActiveInteractor::Interactor::Result }
         it { is_expected.to be_successful }
         it 'is expected not to receive #perform on the first interactor' do
           expect_any_instance_of(test_interactor_1).not_to receive(:perform)
@@ -72,7 +72,7 @@ RSpec.describe 'An organizer with conditionally organized interactors', type: :i
       context 'with context_attributes test_1 and test_2 both eq to false' do
         let(:context_attributes) { { test_1: false, test_2: false } }
 
-        it { is_expected.to be_a interactor_class.context_class }
+        it { is_expected.to be_a ActiveInteractor::Interactor::Result }
         it { is_expected.to be_successful }
         it 'is expected not to receive #perform on the first interactor' do
           expect_any_instance_of(test_interactor_1).not_to receive(:perform)
@@ -109,7 +109,7 @@ RSpec.describe 'An organizer with conditionally organized interactors', type: :i
       context 'with context_attributes test_1 and test_2 both eq to true' do
         let(:context_attributes) { { test_1: true, test_2: true } }
 
-        it { is_expected.to be_a interactor_class.context_class }
+        it { is_expected.to be_a ActiveInteractor::Interactor::Result }
         it { is_expected.to be_successful }
         it 'is expected not to receive #perform on the first interactor' do
           expect_any_instance_of(test_interactor_1).not_to receive(:perform)
@@ -125,7 +125,7 @@ RSpec.describe 'An organizer with conditionally organized interactors', type: :i
       context 'with context_attributes test_1 eq to true and test_2 eq to false' do
         let(:context_attributes) { { test_1: true, test_2: false } }
 
-        it { is_expected.to be_a interactor_class.context_class }
+        it { is_expected.to be_a ActiveInteractor::Interactor::Result }
         it { is_expected.to be_successful }
         it 'is expected not to receive #perform on the first interactor' do
           expect_any_instance_of(test_interactor_1).not_to receive(:perform)
@@ -141,7 +141,7 @@ RSpec.describe 'An organizer with conditionally organized interactors', type: :i
       context 'with context_attributes test_1 eq to false and test_2 eq to true' do
         let(:context_attributes) { { test_1: false, test_2: true } }
 
-        it { is_expected.to be_a interactor_class.context_class }
+        it { is_expected.to be_a ActiveInteractor::Interactor::Result }
         it { is_expected.to be_successful }
         it 'is expected to receive #perform on the first interactor' do
           expect_any_instance_of(test_interactor_1).to receive(:perform)
@@ -157,7 +157,7 @@ RSpec.describe 'An organizer with conditionally organized interactors', type: :i
       context 'with context_attributes test_1 and test_2 both eq to false' do
         let(:context_attributes) { { test_1: false, test_2: false } }
 
-        it { is_expected.to be_a interactor_class.context_class }
+        it { is_expected.to be_a ActiveInteractor::Interactor::Result }
         it { is_expected.to be_successful }
         it 'is expected to receive #perform on both interactors' do
           expect_any_instance_of(test_interactor_1).to receive(:perform)
@@ -192,7 +192,7 @@ RSpec.describe 'An organizer with conditionally organized interactors', type: :i
     describe '.perform' do
       subject { interactor_class.perform }
 
-      it { is_expected.to be_a interactor_class.context_class }
+      it { is_expected.to be_a ActiveInteractor::Interactor::Result }
       it { is_expected.to be_successful }
       it 'is expected to receive #perform on both interactors' do
         expect_any_instance_of(test_interactor_1).to receive(:perform)
@@ -226,7 +226,7 @@ RSpec.describe 'An organizer with conditionally organized interactors', type: :i
     describe '.perform' do
       subject { interactor_class.perform }
 
-      it { is_expected.to be_a interactor_class.context_class }
+      it { is_expected.to be_a ActiveInteractor::Interactor::Result }
       it { is_expected.to be_successful }
       it 'is expected not to receive #perform on the first interactor' do
         expect_any_instance_of(test_interactor_1).not_to receive(:perform)
@@ -264,7 +264,7 @@ RSpec.describe 'An organizer with conditionally organized interactors', type: :i
     describe '.perform' do
       subject { interactor_class.perform }
 
-      it { is_expected.to be_a interactor_class.context_class }
+      it { is_expected.to be_a ActiveInteractor::Interactor::Result }
       it { is_expected.to be_successful }
       it 'is expected not to receive #perform on the first interactor' do
         expect_any_instance_of(test_interactor_1).not_to receive(:perform)
@@ -302,7 +302,7 @@ RSpec.describe 'An organizer with conditionally organized interactors', type: :i
     describe '.perform' do
       subject { interactor_class.perform }
 
-      it { is_expected.to be_a interactor_class.context_class }
+      it { is_expected.to be_a ActiveInteractor::Interactor::Result }
       it { is_expected.to be_successful }
       it 'is expected to receive #perform on both interactors' do
         expect_any_instance_of(test_interactor_1).to receive(:perform)

--- a/spec/integration/an_organizer_with_failing_nested_organizer_spec.rb
+++ b/spec/integration/an_organizer_with_failing_nested_organizer_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe 'An organizer with failing nested organizer', type: :integration 
       expect_any_instance_of(parent_interactor2).not_to receive(:rollback).exactly(:once).and_call_original
     end
 
-    it { is_expected.to be_a parent_interactor_class.context_class }
+    it { is_expected.to be_a ActiveInteractor::Interactor::Result }
 
     it { is_expected.to be_failure }
   end

--- a/spec/integration/an_organizer_with_options_callbacks_spec.rb
+++ b/spec/integration/an_organizer_with_options_callbacks_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe 'An organizer with options callbacks', type: :integration do
   describe '.perform' do
     subject { interactor_class.perform(step: 1) }
 
-    it { is_expected.to be_a interactor_class.context_class }
+    it { is_expected.to be_a ActiveInteractor::Interactor::Result }
     it 'is expected to receive #test_before_method once' do
       expect_any_instance_of(interactor_class).to receive(:test_before_method)
         .exactly(:once)

--- a/spec/support/shared_examples/a_class_that_extends_active_interactor_models_example.rb
+++ b/spec/support/shared_examples/a_class_that_extends_active_interactor_models_example.rb
@@ -8,14 +8,7 @@ RSpec.shared_examples 'A class that extends ActiveInteractor::Models' do
     subject { model_class.new }
 
     it { is_expected.to respond_to :attributes }
-    it { is_expected.to respond_to :called! }
-    it { is_expected.to respond_to :fail! }
-    it { is_expected.to respond_to :fail? }
-    it { is_expected.to respond_to :failure? }
     it { is_expected.to respond_to :merge! }
-    it { is_expected.to respond_to :rollback! }
-    it { is_expected.to respond_to :success? }
-    it { is_expected.to respond_to :successful? }
   end
 
   describe '.new' do
@@ -29,41 +22,17 @@ RSpec.shared_examples 'A class that extends ActiveInteractor::Models' do
 
     describe 'with arguments {:bar => "bar"}' do
       let(:attributes) { model_class.new(bar: 'bar') }
-
-      it { expect { subject }.to raise_error(ActiveModel::UnknownAttributeError) }
     end
 
     describe 'with arguments <#ModelClass foo="foo">' do
       let(:other_instance) { model_class.new(foo: 'foo') }
-      let(:attributes) { other_instance }
+      let(:attributes) { other_instance.attributes }
 
       it { is_expected.to have_attributes(foo: 'foo') }
-
-      context 'with argument instance having @_failed eq to true' do
-        before { other_instance.instance_variable_set('@_failed', true) }
-
-        it { is_expected.to be_failure }
-      end
-
-      context 'with argument instance having @_called eq to ["foo"]' do
-        before { other_instance.instance_variable_set('@_called', %w[foo]) }
-
-        it 'is expected to have instance variable @_called eq to ["foo"]' do
-          expect(subject.instance_variable_get('@_called')).to eq %w[foo]
-        end
-      end
-
-      context 'with argument instance having @_rolled_back eq to true' do
-        before { other_instance.instance_variable_set('@_rolled_back', true) }
-
-        it 'is expected to have instance variable @_rolled_back eq to true' do
-          expect(subject.instance_variable_get('@_rolled_back')).to eq true
-        end
-      end
     end
 
     describe 'with arguments <#OtherClass bar="bar">' do
-      let(:attributes) { model_class.new(other_instance) }
+      let(:attributes) { model_class.new(other_instance.attributes) }
       let!(:other_class) do
         build_class('OtherClass') do
           include ActiveModel::Attributes
@@ -74,8 +43,6 @@ RSpec.shared_examples 'A class that extends ActiveInteractor::Models' do
         end
       end
       let(:other_instance) { other_class.new(bar: 'bar') }
-
-      it { expect { subject }.to raise_error(ActiveModel::UnknownAttributeError) }
     end
   end
 end

--- a/spec/support/shared_examples/a_class_with_interactor_context_methods_example.rb
+++ b/spec/support/shared_examples/a_class_with_interactor_context_methods_example.rb
@@ -17,7 +17,7 @@ RSpec.shared_examples 'a class with interactor context methods' do
     subject { interactor_class.new.context_fail! }
 
     it 'is expected to receive #fail! on instance of .context_class' do
-      expect_any_instance_of(interactor_class.context_class).to receive(:fail!)
+      expect_any_instance_of(ActiveInteractor::Interactor::Result).to receive(:fail!)
         .and_return(true)
       subject
     end
@@ -27,7 +27,7 @@ RSpec.shared_examples 'a class with interactor context methods' do
     subject { interactor_class.new.context_rollback! }
 
     it 'is expected to receive #rollback! on instance of .context_class' do
-      expect_any_instance_of(interactor_class.context_class).to receive(:rollback!)
+      expect_any_instance_of(ActiveInteractor::Interactor::Result).to receive(:rollback!)
         .and_return(true)
       subject
     end
@@ -48,11 +48,11 @@ RSpec.shared_examples 'a class with interactor context methods' do
     let(:instance) { interactor_class.new }
 
     it 'is expected to receive #called! on instance of .context_class' do
-      expect_any_instance_of(interactor_class.context_class).to receive(:called!)
+      expect_any_instance_of(ActiveInteractor::Interactor::State).to receive(:called!)
         .with(instance)
       subject
     end
 
-    it { is_expected.to be_an interactor_class.context_class }
+    it { is_expected.to be_an ActiveInteractor::Interactor::Result }
   end
 end


### PR DESCRIPTION
## Description

<!-- Summarize the pull request -->
ensure interactor returns a `ActiveInteractor::Interactor::Result`

## Information

- [x] Contains Documentation
- [x] Contains Tests
- [ ] Contains Breaking Changes

## Related Issues

<!-- besure to use the github action format for issues -->
<!-- <action> [issue_id] -->
<!-- i.e. "resloves #1" -->
<!-- delete this if there are no related issues -->
- see #270 

## TODO

<!-- delete this if there are no todos-->
- [x] address error failure in the basic organizer spec
- [x] address model spec failures
- [x] update yard docs 
- [ ] open new issues to clean this up in v2.0

## Changelog

<!-- provide any changelog items this pull request implements -->
<!-- follow the keep a changelog format -->
<!-- see https://keepachangelog.com/en/1.0.0/ -->
<!-- delete any unused headings -->

### Changed

- `ActiveInteractor::Base.perform` will now return an `ActiveInteractor::Interactor::Result`
