### PR TITLE
#271 deprecate ActiveInteractor::Context::Status

### DIFF
--- a/lib/active_interactor/context/status.rb
+++ b/lib/active_interactor/context/status.rb
@@ -5,8 +5,12 @@ module ActiveInteractor
     # Context status methods. Because {Status} is a module classes should include {Status} rather than inherit from it.
     #
     # @author Aaron Allen <hello@aaronmallen.me>
+    # @deprecated use {ActiveInteractor::Interactor::State} instead
     # @since 1.0.0
     module Status
+      deprecate :called!, :fail!, :fail?, :failure?, :resolve, :rollback!, :success?, :successful?,
+                deprecator: ActiveInteractor::Deprecation::V2
+
       # Add an instance of {ActiveInteractor::Base interactor} to the list of {ActiveInteractor::Base interactors}
       # called on the {Base context}. This list is used when {#rollback!} is called on a {Base context} instance.
       #


### PR DESCRIPTION
## Description

<!-- Summarize the pull request -->
deprecate `ActiveInteractor::Context::Status`

## Information

- [x] Contains Documentation
- [ ] Contains Tests
- [ ] Contains Breaking Changes

## Related Issues

<!-- besure to use the github action format for issues -->
<!-- <action> [issue_id] -->
<!-- i.e. "resloves #1" -->
<!-- delete this if there are no related issues -->
- see #271 

## Changelog

<!-- provide any changelog items this pull request implements -->
<!-- follow the keep a changelog format -->
<!-- see https://keepachangelog.com/en/1.0.0/ -->
<!-- delete any unused headings -->

### Deprecated

- `ActiveInteractor::Context::Status`
