### PR TITLE
#275 deprecate ActiveInteractor::Context::Errors

### DIFF
--- a/lib/active_interactor/context/errors.rb
+++ b/lib/active_interactor/context/errors.rb
@@ -6,9 +6,12 @@ module ActiveInteractor
     # inherit from it.
     #
     # @api private
+    # @deprecated
     # @author Aaron Allen <hello@aaronmallen.me>
     # @since 1.0.3
     module Errors
+      deprecate :failure_errors, deprecator: ActiveInteractor::Deprecation::V2
+
       # Generic errors generated outside of validation.
       #
       # @return [ActiveModel::Errors] an instance of `ActiveModel::Errors`


### PR DESCRIPTION
## Description

<!-- Summarize the pull request -->
deprecate `ActiveInteractor::Context::Errors`

## Information

- [x] Contains Documentation
- [ ] Contains Tests
- [ ] Contains Breaking Changes

## Related Issues

<!-- besure to use the github action format for issues -->
<!-- <action> [issue_id] -->
<!-- i.e. "resloves #1" -->
<!-- delete this if there are no related issues -->
- see #275 

## Changelog

<!-- provide any changelog items this pull request implements -->
<!-- follow the keep a changelog format -->
<!-- see https://keepachangelog.com/en/1.0.0/ -->
<!-- delete any unused headings -->

### Deprecated

- `ActiveInteractor::Context::Errors`