### PR TITLE
Use ActiveModel::Errors#import on Rails 6.1+

### DIFF
--- a/lib/active_interactor/context/errors.rb
+++ b/lib/active_interactor/context/errors.rb
@@ -40,10 +40,18 @@ module ActiveInteractor
         failure_errors.merge!(other.failure_errors)
       end
 
-      def resolve_errors
-        all_errors = (failure_errors.uniq + errors.uniq).compact.uniq
-        clear_all_errors
-        all_errors.each { |error| errors.add(error[0], error[1]) }
+      if ActiveModel::Errors.method_defined?(:import)
+        def resolve_errors
+          all_errors = (failure_errors.uniq + errors.uniq).compact.uniq
+          clear_all_errors
+          all_errors.each { |error| errors.import(error) }
+        end
+      else
+        def resolve_errors
+          all_errors = (failure_errors.uniq + errors.uniq).compact.uniq
+          clear_all_errors
+          all_errors.each { |error| errors.add(error[0], error[1]) }
+        end
       end
     end
   end

--- a/lib/active_interactor/interactor/result.rb
+++ b/lib/active_interactor/interactor/result.rb
@@ -113,10 +113,18 @@ module ActiveInteractor
         super
       end
 
-      def resolve_errors!
-        all_errors = context.errors.uniq.compact
-        context.errors.clear
-        all_errors.each { |error| context.errors.add(error[0], error[1]) }
+      if ActiveModel::Errors.method_defined?(:import)
+        def resolve_errors!
+          all_errors = context.errors.uniq.compact
+          context.errors.clear
+          all_errors.each { |error| context.errors.import(error) }
+        end
+      else
+        def resolve_errors!
+          all_errors = context.errors.uniq.compact
+          context.errors.clear
+          all_errors.each { |error| context.errors.add(error[0], error[1]) }
+        end
       end
 
       def respond_to_missing?(method_name, include_private = false)


### PR DESCRIPTION
`ActiveModel::Errors#each` was changed in Rails 6.1.0 to iterate across an array of `ActiveModel::Error` objects instead of an array of values like `[attribute, message]`.

This PR begins the Rails 6.1 compatibility process, but it is not complete -- when the specs run, it currently hangs in an infinite loop part way through and uses 100% CPU while leaking memory until exhaustion. I haven't traced this particular issue yet, but wanted to get this PR up early to begin the work and avoid potential duplication of effort.