### PR TITLE
Consider an OpenStruct member as protected if it's an attribute

### DIFF
--- a/activeinteractor.gemspec
+++ b/activeinteractor.gemspec
@@ -37,8 +37,8 @@ Gem::Specification.new do |spec|
     'wiki_uri' => 'https://github.com/aaronmallen/activeinteractor/wiki'
   }
 
-  spec.add_dependency 'activemodel', '>= 4.2', '<= 6.1'
-  spec.add_dependency 'activesupport', '>= 4.2', '<= 6.1'
+  spec.add_dependency 'activemodel', '>= 4.2', '< 6.2'
+  spec.add_dependency 'activesupport', '>= 4.2', '< 6.2'
 
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'rake', '~> 13.0'

--- a/lib/active_interactor/context/attributes.rb
+++ b/lib/active_interactor/context/attributes.rb
@@ -174,6 +174,12 @@ module ActiveInteractor
           self[key] = value
         end
       end
+
+      def is_method_protected!(name)
+        return true if attribute?(name)
+
+        super
+      end
     end
   end
 end


### PR DESCRIPTION
Ruby 3.0 changed OpenStruct in a few backwards incompatible ways,
including the manner in which it determines if a key is protected or
not. For our purposes, we should also consider attributes as protected.

## Description

This patch adds a simple implementation for `ActiveInteractor::Context::Base#is_method_protected!`
that returns `true` if the key name is an attribute. This prevents OpenStruct 
from creating readers and writers for the key, which is currently causing failures
on Ruby 3.0.

This patch is against the 1-1-stable branch rather than main as I am currently using
1.1 in a project and there are other things happening in the main branch so I'd rather
not touch that yet.

## Information

- [x] Contains Documentation
- [x] Contains Tests -- technically no, but all specs pass in both Ruby 2.7 and 3.0
- [ ] Contains Breaking Changes -- nope

## Changelog

### Fixed

* Fix compatibility with OpenStruct changes from Ruby 3.0.
