### PR TITLE
Fix rails dependencies for 6.1.x

### DIFF
--- a/activeinteractor.gemspec
+++ b/activeinteractor.gemspec
@@ -37,8 +37,8 @@ Gem::Specification.new do |spec|
     'wiki_uri' => 'https://github.com/aaronmallen/activeinteractor/wiki'
   }
 
-  spec.add_dependency 'activemodel', '>= 4.2', '<= 6.1'
-  spec.add_dependency 'activesupport', '>= 4.2', '<= 6.1'
+  spec.add_dependency 'activemodel', '>= 4.2', '< 6.2'
+  spec.add_dependency 'activesupport', '>= 4.2', '< 6.2'
 
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'rake', '~> 13.0'


### PR DESCRIPTION
## Description

The gem will install with Rails 6.1.0 but not Rails 6.1.1+ due to the dependency requirements.

## Changelog

### Changed

- Allow for Rails 6.1.x versions to be used.
