### PR TITLE
Refactor AttributeSet

### DIFF
--- a/lib/active_interactor/attribute_set.rb
+++ b/lib/active_interactor/attribute_set.rb
@@ -3,40 +3,68 @@
 require 'active_support/core_ext/array/extract_options'
 require 'active_support/core_ext/module'
 
+require_relative './attribute'
+
 module ActiveInteractor
   class AttributeSet
-    delegate :key?, :keys, :values, to: :@attributes
-    delegate :each, :each_with_object, to: :values
+    delegate :empty?, to: :@attributes
 
-    def initialize(attributes)
-      @attributes = attributes
+    def initialize(*attributes)
+      @attributes = attributes.each_with_object({}) do |attribute, hash|
+        next unless attribute.is_a?(Attribute)
+
+        hash[attribute.name] = attribute
+      end
     end
 
-    def [](name)
-      @attributes[name]
+    def add(*attribute_options)
+      attribute = Attribute.new(**extract_attribute_options!(attribute_options))
+      @attributes[attribute.name] = attribute
     end
 
-    def []=(name, attribute)
-      @attributes[name] = attribute
+    def attribute?(name)
+      @attributes.key?(name)
+    end
+
+    def attribute_names
+      @attributes.keys
+    end
+
+    def clear!
+      @attributes = {}
+      self
     end
 
     def deep_dup
-      AttributeSet.new(@attributes.transform_values(&:dup))
+      AttributeSet.new(*@attributes.transform_values(&:dup).values)
     end
 
-    def fetch_value(name)
-      @attributes[name]&.value
+    def get_attribute(name)
+      @attributes[name]
+    end
+    alias [] get_attribute
+
+    def get_value(name)
+      get_attribute(name)&.value
     end
 
     def to_hash
       @attributes
-        .select { |_name, attribute| attribute.initialized? }
+        .select { |_, attribute| attribute.initialized? }
         .transform_values(&:value)
     end
     alias to_h to_hash
 
     def write_value(name, value)
-      @attributes[name]&.write_value(value)
+      get_attribute(name)&.write_value(value)
+    end
+
+    private
+
+    def extract_attribute_options!(attribute_options)
+      options = attribute_options.extract_options!
+      name, type, description = attribute_options
+      { name: name, type: type, description: description }.merge(options)
     end
   end
 end

--- a/spec/active_interactor/attribute_set_spec.rb
+++ b/spec/active_interactor/attribute_set_spec.rb
@@ -3,92 +3,185 @@
 require 'spec_helper'
 
 RSpec.describe ActiveInteractor::AttributeSet do
-  describe '#[]' do
-    subject(:fetch_attribute) { attribute_set[attribute_name] }
+  describe '#add' do
+    subject(:add) { attribute_set.add(*attribute_options) }
 
-    context 'when attribute exists' do
-      let(:attributes) { { test: instance_double('ActiveInteractor::Attribute') } }
-      let(:attribute_set) { described_class.new(attributes) }
-      let(:attribute_name) { :test }
-
-      it 'is expected to return the attribute' do
-        expect(fetch_attribute).to eq attributes[attribute_name]
-      end
-    end
+    let(:name) { :test }
+    let(:type) { String }
+    let(:attribute_set) { described_class.new }
 
     context 'when attribute does not exist' do
-      let(:attribute_set) { described_class.new({}) }
-      let(:attribute_name) { :test }
+      before do
+        new_attribute
+        allow(ActiveInteractor::Attribute).to receive(:new)
+          .with(name: name, type: type, description: nil)
+          .and_return(new_attribute)
+      end
 
-      it { is_expected.to be_nil }
+      let(:new_attribute) { create_attribute }
+      let(:attribute_options) { [name, type] }
+
+      it { is_expected.to be_a ActiveInteractor::Attribute }
+      it { expect { add }.to change { attribute_set[name] }.from(nil).to(new_attribute) }
+    end
+
+    context 'when attribute exists' do
+      before do
+        attributes
+        allow(ActiveInteractor::Attribute).to receive(:new)
+          .with(name: name, type: type, description: nil)
+          .and_return(attributes.last)
+      end
+
+      let(:attributes) { [create_attribute(name), create_attribute(name)] }
+      let(:attribute_set) { described_class.new(attributes.first) }
+      let(:attribute_options) { [name, type] }
+
+      it { is_expected.to be_a ActiveInteractor::Attribute }
+      it { expect { add }.to change { attribute_set[name] }.from(attributes.first).to(attributes.last) }
+    end
+
+    context 'when given attribute_options for Attribute#name, and Attribute#type' do
+      let(:attribute_options) { [name, type] }
+
+      it { is_expected.to have_attributes(name: name, type: type, description: nil) }
+    end
+
+    context 'when given options for Attribute#name, Attribute#type, and Attribute#description' do
+      let(:description) { 'A test attribute' }
+      let(:attribute_options) { [name, type, description] }
+
+      it { is_expected.to have_attributes(name: name, type: type, description: description) }
+    end
+
+    context 'when given options for Attribute#name, Attribute#type, and an options hash' do
+      let(:options) { { description: 'A test description', required: true, default_value: 'test' } }
+      let(:attribute_options) { [name, type, options] }
+
+      it { is_expected.to have_attributes(name: name, type: type, description: options[:description]) }
+      it { is_expected.to have_attributes(required?: options[:required], default_value: options[:default_value]) }
+    end
+
+    context 'when given an options hash' do
+      let(:options) do
+        {
+          name: name,
+          type: type,
+          description: 'A test description',
+          required: true,
+          default_value: 'test'
+        }
+      end
+      let(:attribute_options) { [options] }
+
+      it { is_expected.to have_attributes(name: name, type: type, description: options[:description]) }
+      it { is_expected.to have_attributes(required?: options[:required], default_value: options[:default_value]) }
     end
   end
 
-  describe '#[]=' do
-    subject(:set_attribute) { attribute_set[attribute_name] = value }
+  describe '#attribute?' do
+    subject(:attribute?) { attribute_set.attribute?(name) }
 
-    context 'when attribute already exists' do
-      let(:attributes) { { test: instance_double('ActiveInteractor::Attribute', value: 'test') } }
-      let(:attribute_set) { described_class.new(attributes) }
-      let(:attribute_name) { :test }
-      let(:value) { instance_double('ActiveInteractor::Attribute', value: 'new_test') }
+    let(:name) { :test }
 
-      it 'is expected to override the existing value' do
-        set_attribute
+    context 'when attribute exists' do
+      let(:attribute) { create_attribute(name) }
+      let(:attribute_set) { described_class.new(attribute) }
 
-        expect(attribute_set[attribute_name]).to eq value
-      end
+      it { is_expected.to eq true }
     end
 
-    context 'when attribute does not exist' do
-      let(:attribute_set) { described_class.new({}) }
-      let(:attribute_name) { :test }
-      let(:value) { instance_double('ActiveInteractor::Attribute') }
+    context 'when attribute does not exists' do
+      let(:attribute_set) { described_class.new }
 
-      it 'is expected to set the new value' do
-        set_attribute
-
-        expect(attribute_set[attribute_name]).to eq value
-      end
+      it { is_expected.to eq false }
     end
+  end
+
+  describe '#attribute_names' do
+    subject(:attribute_names) { attribute_set.attribute_names }
+
+    let(:attribute) { create_attribute }
+    let(:attribute_set) { described_class.new(attribute) }
+
+    it { is_expected.to eq [attribute.name] }
+  end
+
+  describe '#clear!' do
+    subject(:clear!) { attribute_set.clear! }
+
+    let(:attribute_set) { described_class.new(create_attribute) }
+
+    it { is_expected.to be_empty }
   end
 
   describe '#deep_dup' do
     subject(:deep_dup) { attribute_set.deep_dup }
 
-    context 'when AttributeSet has attributes' do
-      let(:attributes) { { test: instance_double('ActiveInteractor::Attribute') } }
-      let(:attribute_set) { described_class.new(attributes) }
+    before { allow(attribute).to receive(:dup).and_return(dupped_attribute) }
 
-      it { is_expected.not_to eq attribute_set }
-      it { is_expected.to be_a described_class }
+    let(:attribute) { create_attribute }
+    let(:dupped_attribute) { create_attribute }
+    let(:attribute_set) { described_class.new(attribute) }
 
-      it 'is expected to dup each attribute' do
-        attributes.each { |_name, attribute| allow(attribute).to receive(:dup) }
-        deep_dup
+    it { is_expected.to be_an described_class }
+    it { is_expected.not_to eq attribute_set }
 
-        attributes.each { |_name, attribute| expect(attribute).to have_received(:dup) }
-      end
+    it 'is expected to dup Attributes' do
+      expect(deep_dup[attribute.name]).to eq dupped_attribute
     end
   end
 
-  describe '#fetch_value' do
-    subject(:fetch_value) { attribute_set.fetch_value(attribute_name) }
+  describe '#empty?' do
+    subject(:empty?) { attribute_set.empty? }
+
+    context 'when AttributeSet has no attributes' do
+      let(:attribute_set) { described_class.new }
+
+      it { is_expected.to eq true }
+    end
+
+    context 'when AttributeSet has attributes' do
+      let(:attribute_set) { described_class.new(create_attribute) }
+
+      it { is_expected.to eq false }
+    end
+  end
+
+  describe '#get_attribute' do
+    subject(:get_attribute) { attribute_set.get_attribute(name) }
+
+    let(:name) { :test }
+
+    context 'when attribute exists' do
+      let(:attribute) { create_attribute(name) }
+      let(:attribute_set) { described_class.new(attribute) }
+
+      it { is_expected.to eq attribute }
+    end
+
+    context 'when attribute does not exists' do
+      let(:attribute_set) { described_class.new }
+
+      it { is_expected.to be_nil }
+    end
+  end
+
+  describe '#get_value' do
+    subject(:get_value) { attribute_set.get_value(name) }
+
+    let(:name) { :test }
 
     context 'when attribute exists' do
       let(:value) { 'test' }
-      let(:attributes) { { test: instance_double('ActiveInteractor::Attribute', value: value) } }
-      let(:attribute_set) { described_class.new(attributes) }
-      let(:attribute_name) { :test }
+      let(:attribute) { create_attribute_with_value(value, name: name) }
+      let(:attribute_set) { described_class.new(attribute) }
 
-      it 'is expected to return the attribute value' do
-        expect(fetch_value).to eq value
-      end
+      it { is_expected.to eq value }
     end
 
-    context 'when attribute does not exist' do
-      let(:attribute_set) { described_class.new({}) }
-      let(:attribute_name) { :test }
+    context 'when attribute does not exists' do
+      let(:attribute_set) { described_class.new }
 
       it { is_expected.to be_nil }
     end
@@ -98,45 +191,52 @@ RSpec.describe ActiveInteractor::AttributeSet do
     subject(:to_hash) { attribute_set.to_hash }
 
     context 'when AttributeSet has initialized and uninitialized attributes' do
-      let(:initialized_attribute) { instance_double('ActiveInteractor::Attribute', value: 'test', initialized?: true) }
-      let(:uninitialized_attribute) { instance_double('ActiveInteractor::Attribute', initialized?: false) }
-      let(:attribute_set) { described_class.new(a: initialized_attribute, b: uninitialized_attribute) }
+      let(:initialized_attribute) { create_attribute_with_value('value', name: :test1) }
+      let(:uninitialized_attribute) { create_attribute(:test2) }
+      let(:attribute_set) { described_class.new(initialized_attribute, uninitialized_attribute) }
 
-      it { is_expected.to be_a Hash }
-
-      it 'is expected to return the appropriate hash' do
-        expect(to_hash).to eq({ a: initialized_attribute.value })
-      end
+      it { is_expected.to eq({ initialized_attribute.name => initialized_attribute.value }) }
     end
   end
 
   describe '#write_value' do
-    subject(:write_value) { attribute_set.write_value(attribute_name, value) }
+    subject(:write_value) { attribute_set.write_value(name, value) }
 
-    context 'when attribute exists' do
-      let(:attribute) { instance_double('ActiveInteractor::Attribute') }
-      let(:attribute_name) { :test }
-      let(:attribute_set) { described_class.new(attribute_name => attribute) }
+    let(:name) { :test }
+
+    context 'when attribute exists and has no value' do
+      let(:attribute_set) { described_class.new(create_attribute(name)) }
       let(:value) { 'test' }
 
-      it 'is expected to write the attribute value' do
-        allow(attribute).to receive(:write_value)
-        write_value
-
-        expect(attribute).to have_received(:write_value).with(value)
-      end
+      it { is_expected.to eq value }
+      it { expect { write_value }.to change { attribute_set[name].value }.from(nil).to(value) }
     end
 
-    context 'when attribute does not exists' do
-      let(:attribute_name) { :test }
-      let(:attribute_set) { described_class.new({}) }
+    context 'when attribute exists and has a value' do
+      let(:old_value) { 'old value' }
+      let(:attribute_set) { described_class.new(create_attribute_with_value(old_value, name: name)) }
+      let(:value) { 'new value' }
+
+      it { is_expected.to eq value }
+      it { expect { write_value }.to change { attribute_set[name].value }.from(old_value).to(value) }
+    end
+
+    context 'when attribute does not exist' do
+      let(:attribute_set) { described_class.new }
       let(:value) { 'test' }
 
-      it 'is expected not to write an attribute value' do
-        write_value
-
-        expect(attribute_set[attribute_name]).to be_nil
-      end
+      it { is_expected.to be_nil }
     end
+  end
+
+  def create_attribute(name = :test, options = {})
+    attribute_options = { name: name, type: String }.merge(options)
+    ActiveInteractor::Attribute.new(**attribute_options)
+  end
+
+  def create_attribute_with_value(value, options = {})
+    attribute = create_attribute(options[:name], options)
+    attribute.write_value(value)
+    attribute
   end
 end


### PR DESCRIPTION
## Description

<!-- Summarize the pull request -->
AttributeSet is meant to be a collection of Attributes. Therefor the class can afford to be coupled to the Attribute class for easier use.


## Information

- [ ] Contains Documentation
- [x] Contains Tests
- [x] Contains Breaking Changes


## Changelog

<!-- provide any changelog items this pull request implements -->
<!-- follow the keep a changelog format -->
<!-- see https://keepachangelog.com/en/1.0.0/ -->
<!-- delete any unused headings -->

### Added

- `ActiveInteractor::AttributeSet#add`
- `ActiveInteractor::AttributeSet#attribute?`
- `ActiveInteractor::AttributeSet#attribute_names`
- `ActiveInteractor::AttributeSet#clear!`
- `ActiveInteractor::AttributeSet#empty?`
- `ActiveInteractor::AttributeSet#get_attribute`
- `ActiveInteractor::AttributeSet#get_value`

### Changed

- `ActiveInteractor::AttributeSet.new` now takes a splat of `ActiveInteractor::Attribute`

### Removed

- `ActiveInteractor::AttributeSet#[]=`
- `ActiveInteractor::AttributeSet#each`
- `ActiveInteractor::AttributeSet#each_with_object`
- `ActiveInteractor::AttributeSet#fetch_value`
- `ActiveInteractor::AttributeSet#key?`
- `ActiveInteractor::AttributeSet#keys`
- `ActiveInteractor::AttributeSet#values`
