### PR TITLE
Bump activemodel and activesupport to 6.1.4.6

### DIFF
--- a/activeinteractor.gemspec
+++ b/activeinteractor.gemspec
@@ -36,8 +36,8 @@ Gem::Specification.new do |spec|
     'wiki_uri' => 'https://github.com/aaronmallen/activeinteractor/wiki'
   }
 
-  spec.add_dependency 'activemodel', '>= 4.2', '<= 6.1.4.4'
-  spec.add_dependency 'activesupport', '>= 4.2', '<= 6.1.4.4'
+  spec.add_dependency 'activemodel', '>= 4.2', '<= 6.1.4.6'
+  spec.add_dependency 'activesupport', '>= 4.2', '<= 6.1.4.6'
 
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'rake', '~> 13.0'


### PR DESCRIPTION
After updating Rails version to 6.1.4.6 we have new dependencies activemodel and activesupport.

## Changelog
Bump activemodel and activesupport to 6.1.4.6

###  Changed
activemodel and activesupport dependencies from <= 6.1.4.4 to <= 6.1.4.6