### PR TITLE
Bump activemodel and activesupport to 7.0.2.3

### DIFF
--- a/.rubocop/style.yml
+++ b/.rubocop/style.yml
@@ -2,3 +2,5 @@ Style/Documentation:
   Enabled: false
 Style/OptionalBooleanParameter:
   Enabled: false
+Layout/BlockAlignment:
+  Enabled: false

--- a/activeinteractor.gemspec
+++ b/activeinteractor.gemspec
@@ -36,8 +36,8 @@ Gem::Specification.new do |spec|
     'wiki_uri' => 'https://github.com/aaronmallen/activeinteractor/wiki'
   }
 
-  spec.add_dependency 'activemodel', '>= 4.2', '<= 6.1.4.6'
-  spec.add_dependency 'activesupport', '>= 4.2', '<= 6.1.4.6'
+  spec.add_dependency 'activemodel', '>= 4.2', '<= 7.0.2.3'
+  spec.add_dependency 'activesupport', '>= 4.2', '<= 7.0.2.3'
 
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'rake', '~> 13.0'

--- a/spec/support/shared_examples/a_class_with_interactor_callback_methods_example.rb
+++ b/spec/support/shared_examples/a_class_with_interactor_callback_methods_example.rb
@@ -8,7 +8,7 @@ RSpec.shared_examples 'a class with interactor callback methods' do
 
     it 'is expected to receive #set_callback with :validation, :after, :some_method, { :prepend => true }' do
       expect(interactor_class).to receive(:set_callback)
-        .with(:validation, :after, :some_method, prepend: true)
+        .with(:validation, :after, :some_method, { prepend: true })
         .and_return(true)
       subject
     end


### PR DESCRIPTION
## Description

<!-- Summarize the pull request -->
To support Ruby on Rails 7, bump activemodel and activesupport to 7.0.2.3

## Information

- [ ] Contains Documentation
- [x] Contains Tests
- [ ] Contains Breaking Changes

## Changelog

<!-- provide any changelog items this pull request implements -->
<!-- follow the keep a changelog format -->
<!-- see https://keepachangelog.com/en/1.0.0/ -->
<!-- delete any unused headings -->

### Changed

- Bump activemodel and activesupport to 7.0.2.3
- Disable Layout/BlockAlignment in RuboCop

