### PR TITLE
Defer until after `perform` instead of `all_perform`

### DIFF
--- a/lib/active_interactor/interactor/worker.rb
+++ b/lib/active_interactor/interactor/worker.rb
@@ -60,10 +60,16 @@ module ActiveInteractor
       end
 
       def execute_context_with_callbacks!
-        interactor.run_callbacks :perform do
+        result = interactor.run_callbacks :perform do
           execute_context_with_validation_check!
           @context = interactor.finalize_context!
         end
+
+        if context&.success? && interactor.respond_to?(:run_deferred_after_perform_callbacks_on_children)
+          interactor.run_deferred_after_perform_callbacks_on_children
+        end
+
+        result
       end
 
       def execute_context_with_validation!

--- a/lib/active_interactor/organizer/perform.rb
+++ b/lib/active_interactor/organizer/perform.rb
@@ -53,7 +53,14 @@ module ActiveInteractor
             perform_in_order
           end
         end
-        run_after_perform_callbacks_on_interactors if context.success?
+      end
+
+      def run_deferred_after_perform_callbacks_on_children
+        self.class.organized.each do |interface|
+          next unless interface.interactor_class.after_callbacks_deferred_when_organized
+
+          context.merge!(interface.execute_deferred_after_perform_callbacks(context))
+        end
       end
 
       private
@@ -99,14 +106,6 @@ module ActiveInteractor
           Thread.new { execute_interactor_with_callbacks(interface, false, skip_rollback: true) }
         end
         merge_contexts(results.map(&:value))
-      end
-
-      def run_after_perform_callbacks_on_interactors
-        self.class.organized.each do |interface|
-          next unless interface.interactor_class.after_callbacks_deferred_when_organized
-
-          context.merge!(interface.execute_deferred_after_perform_callbacks(context))
-        end
       end
     end
   end


### PR DESCRIPTION
## Description

`all_perform` is a redundant set of callbacks and is entirely enveloped by the Organizer's `perform` callbacks. This change moves the execution of the deferred callbacks to after `perform` rather than `all_perform` to better match the intent of the `defer_after_callbacks_when_organized` attribute.

The impact of this should be very minimal as, in both cases, the callbacks are still deferred until after all nested interactors have finished. 

## Information

- ~[ ] Contains Documentation~ It's a bug fix for logic that is already documented.
- ~[ ] Contains Tests~ Left tests unmodified to validate it is not a breaking change
- ~[ ] Contains Breaking Changes~ Does not.

## Changelog

### Fixed

- Fixes a minor timing issue for when deferred `after_perform` callbacks are run. 
